### PR TITLE
Prepare for Julia 0.4

### DIFF
--- a/src/ODBC.jl
+++ b/src/ODBC.jl
@@ -7,9 +7,9 @@ if VERSION < v"0.4-"
     using Dates
 end
 
-export advancedconnect, 
-       query, querymeta, @query, @sql_str, 
-       Connection, Metadata, conn, Connections, 
+export advancedconnect,
+       query, querymeta, @query, @sql_str,
+       Connection, Metadata, conn, Connections,
        disconnect, listdrivers, listdsns
 
 include("ODBC_Types.jl")
@@ -41,20 +41,20 @@ Base.show(io::IO,meta::Metadata) = begin
                               Sizes=meta.colsizes,
                               Digits=meta.coldigits,
                               Nullable=meta.colnulls))
-    end 
+    end
 end
 
-# Connection object holds information related to each 
+# Connection object holds information related to each
 # established connection and retrieved resultsets
 type Connection
     dsn::String
     number::Int
     dbc_ptr::Ptr{Void}
     stmt_ptr::Ptr{Void}
-    
-    # Holding a reference to the last resultset is useful if the user 
-    # runs several test queries just using `query()` or `sql"..."` and 
-    # then realizes the last resultset should actually be saved to a variable. 
+
+    # Holding a reference to the last resultset is useful if the user
+    # runs several test queries just using `query()` or `sql"..."` and
+    # then realizes the last resultset should actually be saved to a variable.
     resultset::Any
 end
 
@@ -69,7 +69,7 @@ Base.show(io::IO,conn::Connection) = begin
         if conn.resultset == null_resultset
             print(io, "Contains resultset(s)? No")
         else
-            print(io, "Contains resultset(s)? Yes") 
+            print(io, "Contains resultset(s)? Yes")
         end
     end
 end
@@ -86,7 +86,7 @@ const null_conn = Connection("", 0, C_NULL, C_NULL, null_resultset)
 global env = C_NULL
 
 # For managing references to multiple connections
-global Connections = Connection[] 
+global Connections = Connection[]
 
 #Create default connection = null
 global conn = null_conn

--- a/src/ODBC.jl
+++ b/src/ODBC.jl
@@ -1,8 +1,11 @@
 module ODBC
 
+using Compat
 using DataFrames
 using DataArrays
-using Dates
+if VERSION < v"0.4-"
+    using Dates
+end
 
 export advancedconnect, 
        query, querymeta, @query, @sql_str, 
@@ -18,7 +21,7 @@ type Metadata
     cols::Int
     rows::Int
     colnames::Array{UTF8String}
-    coltypes::Array{(String, Int16)}
+    @compat coltypes::Array{Tuple{String, Int16}}
     colsizes::Array{Int}
     coldigits::Array{Int16}
     colnulls::Array{Int16}
@@ -78,7 +81,7 @@ typealias Output Union(DataType,String)
 
 const null_resultset = DataFrame()
 const null_conn = Connection("", 0, C_NULL, C_NULL, null_resultset)
-const null_meta = Metadata("", 0, 0, UTF8String[], (String,Int16)[], Int[], Int16[], Int16[])
+@compat const null_meta = Metadata("", 0, 0, UTF8String[], Tuple{String,Int16}[], Int[], Int16[], Int16[])
 
 global env = C_NULL
 

--- a/src/ODBC_API.jl
+++ b/src/ODBC_API.jl
@@ -20,12 +20,12 @@
  #Resultset Retrieval Functions
  #DBMS Meta Functions
  #Error Handling and Diagnostics
- 
+
 #### Macros and Utility Functions ####
 
-# MULTIROWFETCH sets the default rowset fetch size 
+# MULTIROWFETCH sets the default rowset fetch size
 # used in retrieving resultset blocks from queries
-const MULTIROWFETCH = 65535 
+const MULTIROWFETCH = 65535
 
 # success codes
 @compat const SQL_SUCCESS           = Int16(0)
@@ -62,24 +62,24 @@ macro FAILED(func)
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms712400(v=vs.85).aspx
-function SQLDrivers(env::Ptr{Void}, 
-                    driver_desc::Array{Uint8,1}, 
-                    desc_length::Array{Int16,1}, 
-                    driver_attr::Array{Uint8,1}, 
+function SQLDrivers(env::Ptr{Void},
+                    driver_desc::Array{Uint8,1},
+                    desc_length::Array{Int16,1},
+                    driver_attr::Array{Uint8,1},
                     attr_length::Array{Int16,1})
-    @windows_only begin 
+    @windows_only begin
         ret = ccall((:SQLDrivers, odbc_dm), stdcall, Int16,
-                    (Ptr{Void}, Int16, Ptr{Uint8}, 
+                    (Ptr{Void}, Int16, Ptr{Uint8},
                     Int16, Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
-                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc), 
-                    desc_length, driver_attr, length(driver_attr), attr_length) 
+                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc),
+                    desc_length, driver_attr, length(driver_attr), attr_length)
     end
     @unix_only begin
         ret = ccall((:SQLDrivers, odbc_dm), Int16,
-                    (Ptr{Void}, Int16, Ptr{Uint8}, 
+                    (Ptr{Void}, Int16, Ptr{Uint8},
                      Int16, Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
-                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc), 
-                    desc_length, driver_attr, length(driver_attr), attr_length) 
+                    env, SQL_FETCH_NEXT, driver_desc, length(driver_desc),
+                    desc_length, driver_attr, length(driver_attr), attr_length)
     end
     return ret
 end
@@ -91,18 +91,18 @@ function SQLDataSources(env::Ptr{Void},
                         dsn_attr::Array{Uint8,1},
                         attr_length::Array{Int16,1})
     @windows_only begin
-        ret = ccall((:SQLDataSources, odbc_dm), stdcall, Int16, 
-                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16, 
+        ret = ccall((:SQLDataSources, odbc_dm), stdcall, Int16,
+                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16,
                      Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
                     env, SQL_FETCH_NEXT, dsn_desc, length(dsn_desc),
-                    desc_length, dsn_attr, length(dsn_attr), attr_length) 
+                    desc_length, dsn_attr, length(dsn_attr), attr_length)
     end
     @unix_only begin
         ret = ccall((:SQLDataSources, odbc_dm), Int16,
-                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16, 
+                    (Ptr{Void}, Int16, Ptr{Uint8}, Int16,
                      Ptr{Int16}, Ptr{Uint8}, Int16, Ptr{Int16}),
                     env, SQL_FETCH_NEXT, dsn_desc, length(dsn_desc),
-                    desc_length, dsn_attr, length(dsn_attr), attr_length) 
+                    desc_length, dsn_attr, length(dsn_attr), attr_length)
     end
     return ret
 end
@@ -122,14 +122,14 @@ const SQL_NULL_HANDLE = C_NULL
 #Status: Tested on Windows, Linux, Mac 32/64-bit
 function SQLAllocHandle(handletype::Int16, parenthandle::Ptr{Void}, handle::Array{Ptr{Void},1})
     @windows_only begin
-        ret = ccall((:SQLAllocHandle, odbc_dm), stdcall, Int16, 
+        ret = ccall((:SQLAllocHandle, odbc_dm), stdcall, Int16,
                     (Int16, Ptr{Void}, Ptr{Void}),
-                    handletype, parenthandle, handle) 
+                    handletype, parenthandle, handle)
     end
     @unix_only begin
         ret = ccall((:SQLAllocHandle, odbc_dm), Int16,
                     (Int16, Ptr{Void}, Ptr{Void}),
-                    handletype, parenthandle, handle) 
+                    handletype, parenthandle, handle)
     end
     return ret
 end
@@ -139,7 +139,7 @@ end
 # Description: frees resources associated with a specific environment, connection, statement, or descriptor handle
 # See SQLAllocHandle for valid handle types
 # Status: Tested on Windows, Linux, Mac 32/64-bit
-function SQLFreeHandle(handletype::Int16,handle::Ptr{Void}) 
+function SQLFreeHandle(handletype::Int16,handle::Ptr{Void})
     @windows_only begin
         ret = ccall((:SQLFreeHandle, odbc_dm), stdcall, Int16,
                     (Int16, Ptr{Void}), handletype, handle)
@@ -165,7 +165,7 @@ const SQL_ATTR_CP_MATCH = 202
 @compat const SQL_CP_STRICT_MATCH = UInt(0)
 const SQL_ATTR_ODBC_VERSION = 200
 const SQL_OV_ODBC2 = 2
-const SQL_OV_ODBC3 = 3 
+const SQL_OV_ODBC3 = 3
 const SQL_ATTR_OUTPUT_NTS = 10001
 const SQL_TRUE = 1
 const SQL_FALSE = 0
@@ -173,12 +173,12 @@ const SQL_FALSE = 0
 #Status: Tested on Windows, Linux, Mac 32/64-bit
 function SQLSetEnvAttr{T<:Union(Int,Uint)}(env_handle::Ptr{Void}, attribute::Int, value::T)
     @windows_only begin
-        ret = ccall((:SQLSetEnvAttr, odbc_dm), stdcall, Int16, 
-                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0) 
+        ret = ccall((:SQLSetEnvAttr, odbc_dm), stdcall, Int16,
+                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0)
     end
     @unix_only begin
-        ret = ccall((:SQLSetEnvAttr, odbc_dm), Int16, 
-                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0) 
+        ret = ccall((:SQLSetEnvAttr, odbc_dm), Int16,
+                    (Ptr{Void}, Int, T, Int), env_handle, attribute, value, 0)
     end
     return ret
 end
@@ -187,17 +187,17 @@ end
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms709276(v=vs.85).aspx
 # Description: returns the current setting of an environment attribute
 # Valid attributes: See SQLSetEnvAttr
-# Status: 
+# Status:
 function SQLGetEnvAttr(env::Ptr{Void},attribute::Int,value::Array{Int,1},bytes_returned::Array{Int,1})
     @windows_only begin
-        ret = ccall((:SQLGetEnvAttr, odbc_dm), stdcall, Int16, 
+        ret = ccall((:SQLGetEnvAttr, odbc_dm), stdcall, Int16,
                     (Ptr{Void}, Int, Ptr{Int}, Int, Ptr{Int}),
-                    env, attribute, value, 0, bytes_returned) 
+                    env, attribute, value, 0, bytes_returned)
     end
     @unix_only begin
-        ret = ccall((:SQLGetEnvAttr, odbc_dm), Int16, 
+        ret = ccall((:SQLGetEnvAttr, odbc_dm), Int16,
                     (Ptr{Void}, Int, Ptr{Int}, Int, Ptr{Int}),
-                    env, attribute, value, 0, bytes_returned) 
+                    env, attribute, value, 0, bytes_returned)
     end
     return ret
 end
@@ -209,14 +209,14 @@ end
 const SQL_ATTR_ACCESS_MODE = 101
 @compat const SQL_MODE_READ_ONLY = UInt(1)
 @compat const SQL_MODE_READ_WRITE = UInt(0)
-#const SQL_ATTR_ASYNC_DBC_EVENT 
+#const SQL_ATTR_ASYNC_DBC_EVENT
 #pointer
-#const SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE 
+#const SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
 #@compat const SQL_ASYNC_DBC_ENABLE_ON = UInt()
 #@compat const SQL_ASYNC_DBC_ENABLE_OFF = UInt()
-#const SQL_ATTR_ASYNC_DBC_PCALLBACK 
+#const SQL_ATTR_ASYNC_DBC_PCALLBACK
 #pointer
-#const SQL_ATTR_ASYNC_DBC_PCONTEXT 
+#const SQL_ATTR_ASYNC_DBC_PCONTEXT
 #pointer
 const SQL_ATTR_ASYNC_ENABLE = 4
 @compat const SQL_ASYNC_ENABLE_OFF = UInt(0)
@@ -228,10 +228,10 @@ const SQL_ATTR_CONNECTION_TIMEOUT = 113
 #uint of how long you want the connection timeout
 const SQL_ATTR_CURRENT_CATALOG = 109
 #string/Ptr{Uint8} of default database to use
-#const SQL_ATTR_DBC_INFO_TOKEN 
+#const SQL_ATTR_DBC_INFO_TOKEN
 #pointer
 const SQL_ATTR_ENLIST_IN_DTC = 1207
-#pointer: Pass a DTC OLE transaction object that specifies the transaction to export to 
+#pointer: Pass a DTC OLE transaction object that specifies the transaction to export to
 # SQL Server, or SQL_DTC_DONE to end the connection's DTC association.
 const SQL_ATTR_LOGIN_TIMEOUT = 103
 #uint of how long you want the login timeout
@@ -251,10 +251,10 @@ const SQL_ATTR_TRACE = 104
 const SQL_ATTR_TRACEFILE = 105
 #A null-terminated character string containing the name of the trace file.
 const SQL_ATTR_TRANSLATE_LIB = 106
-# A null-terminated character string containing the name of a library containing the functions SQLDriverToDataSource and 
+# A null-terminated character string containing the name of a library containing the functions SQLDriverToDataSource and
 # SQLDataSourceToDriver that the driver accesses to perform tasks such as character set translation.
 const SQL_ATTR_TRANSLATE_OPTION = 107
-#A 32-bit flag value that is passed to the translation DLL. 
+#A 32-bit flag value that is passed to the translation DLL.
 const SQL_ATTR_TXN_ISOLATION = 108
 #A 32-bit bitmask that sets the transaction isolation level for the current connection.
 
@@ -269,10 +269,10 @@ const SQL_NTS = -3
 function SQLSetConnectAttr(dbc::Ptr{Void},attribute::Int,value::Union(String,Uint),value_length::Int)
     @windows_only ret = ccall( (:SQLSetConnectAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,typeof(value)==String?Ptr{Uint8}:Ptr{Uint},Int),
-        dbc,attribute,value,value_length) 
+        dbc,attribute,value,value_length)
     @unix_only ret = ccall( (:SQLSetConnectAttr, odbc_dm),
             Int16, (Ptr{Void},Int,typeof(value)==String?Ptr{Uint8}:Ptr{Uint},Int),
-            dbc,attribute,value,value_length) 
+            dbc,attribute,value,value_length)
     return ret
 end
 
@@ -289,10 +289,10 @@ const SQL_CD_FALSE = 0
 function SQLGetConnectAttr{T,N}(dbc::Ptr{Void},attribute::Int,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetConnectAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-        dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+        dbc,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetConnectAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-            dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+            dbc,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
@@ -309,20 +309,20 @@ const SQL_ATTR_ROW_ARRAY_SIZE = 27
 function SQLSetStmtAttr(stmt::Ptr{Void},attribute::Int,value::Uint,value_length::Int)
     @windows_only ret = ccall( (:SQLSetStmtAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Uint,Int),
-        stmt,attribute,value,value_length) 
+        stmt,attribute,value,value_length)
     @unix_only ret = ccall( (:SQLSetStmtAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Uint,Int),
-            stmt,attribute,value,value_length) 
+            stmt,attribute,value,value_length)
     return ret
 end
 
 function SQLSetStmtAttr(stmt::Ptr{Void},attribute::Int,value::Array{Int},value_length::Int)
     @windows_only ret = ccall( (:SQLSetStmtAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{Int},Int),
-        stmt,attribute,value,value_length) 
+        stmt,attribute,value,value_length)
     @unix_only ret = ccall( (:SQLSetStmtAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{Int},Int),
-            stmt,attribute,value,value_length) 
+            stmt,attribute,value,value_length)
     return ret
 end
 
@@ -330,18 +330,18 @@ end
 function SQLGetStmtAttr{T,N}(stmt::Ptr{Void},attribute::Int,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetStmtAttr, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-        stmt,attribute,value,sizeof(T)*N,bytes_returned) 
+        stmt,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetStmtAttr, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-            stmt,attribute,value,sizeof(T)*N,bytes_returned) 
+            stmt,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
 #SQLFreeStmt
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms709284(v=vs.85).aspx
-#Description: stops processing associated with a specific statement, 
-# closes any open cursors associated with the statement, 
-# discards pending results, or, optionally, 
+#Description: stops processing associated with a specific statement,
+# closes any open cursors associated with the statement,
+# discards pending results, or, optionally,
 # frees all resources associated with the statement handle.
 #Valid param
 @compat const SQL_CLOSE = UInt16(0)
@@ -350,12 +350,12 @@ end
 
 #Status:
 @compat function SQLFreeStmt(stmt::Ptr{Void},param::UInt16)
-    @windows_only ret = ccall( (:SQLFreeStmt, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},UInt16), 
-        stmt, param) 
+    @windows_only ret = ccall( (:SQLFreeStmt, odbc_dm), stdcall,
+        Int16, (Ptr{Void},UInt16),
+        stmt, param)
     @unix_only ret = ccall( (:SQLFreeStmt, odbc_dm),
-            Int16, (Ptr{Void},UInt16), 
-            stmt, param) 
+            Int16, (Ptr{Void},UInt16),
+            stmt, param)
     return ret
 end
 
@@ -363,10 +363,10 @@ end
 function SQLSetDescField{T,N}(desc::Ptr{Void},i::Int16,field_id::Int16,value::Array{T,N},value_length::Array{Int,1})
     @windows_only ret = ccall( (:SQLSetDescField, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int),
-        desc,field_id,value,value_length) 
+        desc,field_id,value,value_length)
     @unix_only ret = ccall( (:SQLSetDescField, odbc_dm),
             Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int),
-            desc,field_id,value,value_length) 
+            desc,field_id,value,value_length)
     return ret
 end
 
@@ -374,10 +374,10 @@ end
 function SQLGetDescField{T,N}(desc::Ptr{Void},i::Int16,attribute::Int16,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetDescField, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int,Ptr{Int}),
-        desc,attribute,value,sizeof(T)*N,bytes_returned) 
+        desc,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetDescField, odbc_dm),
             Int16, (Ptr{Void},Int16,Int16,Ptr{T},Int,Ptr{Int}),
-            desc,attribute,value,sizeof(T)*N,bytes_returned) 
+            desc,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
@@ -385,10 +385,10 @@ end
 function SQLGetDescRec(desc::Ptr{Void},i::Int16,name::Array{Uint8,1},name_length::Array{Int16,1},type_ptr::Array{Int16,1},subtype_ptr::Array{Int16,1},length_ptr::Array{Int,1},precision_ptr::Array{Int16,1},scale_ptr::Array{Int16,1},nullable_ptr::Array{Int16,1},)
     @windows_only ret = ccall( (:SQLGetDescRec, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16},Ptr{Int16}),
-        desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr) 
+        desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr)
     @unix_only ret = ccall( (:SQLGetDescRec, odbc_dm),
             Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16},Ptr{Int16}),
-            desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr) 
+            desc,i,name,length(name),name_length,type_ptr,subtype_ptr,length_ptr,precision_ptr,scale_ptr,nullable_ptr)
     return ret
 end
 
@@ -396,25 +396,25 @@ end
 function SQLCopyDesc(source_desc::Ptr{Void},dest_desc::Ptr{Void})
     @windows_only ret = ccall( (:SQLCopyDesc, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Void}),
-        source_desc,dest_desc) 
+        source_desc,dest_desc)
     @unix_only ret = ccall( (:SQLCopyDesc, odbc_dm),
             Int16, (Ptr{Void},Ptr{Void}),
-            source_desc,dest_desc) 
+            source_desc,dest_desc)
     return ret
 end
 
-### Connection Functions ### 
+### Connection Functions ###
 # SQLConnect
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms711810(v=vs.85).aspx
 # Description: establishes connections to a driver and a data source
 # Status:
 function SQLConnect(dbc::Ptr{Void},dsn::String,username::String,password::String)
-    @windows_only ret = ccall( (:SQLConnect, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLConnect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        dbc,dsn,length(dsn),username,length(username),password,length(password)) 
+        dbc,dsn,length(dsn),username,length(username),password,length(password))
     @unix_only ret = ccall( (:SQLConnect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            dbc,dsn,length(dsn),username,length(username),password,length(password)) 
+            dbc,dsn,length(dsn),username,length(username),password,length(password))
     return ret
 end
 
@@ -428,12 +428,12 @@ end
 @compat const SQL_DRIVER_PROMPT = UInt16(2)
 #Status:
 @compat function SQLDriverConnect(dbc::Ptr{Void},window_handle::Ptr{Void},conn_string::String,out_conn::Ptr{Void},out_buff::Array{Int16,1},driver_prompt::UInt16)
-    @windows_only ret = ccall( (:SQLDriverConnect, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLDriverConnect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},UInt16),
-        dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt) 
+        dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt)
     @unix_only ret = ccall( (:SQLDriverConnect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},UInt16),
-            dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt) 
+            dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt)
     return ret
 end
 #SQLBrowseConnect
@@ -443,10 +443,10 @@ end
 function SQLBrowseConnect(dbc::Ptr{Void},instring::String,outstring::Array{Uint8,1},indicator::Array{Int16,1})
     @windows_only ret = ccall( (:SQLBrowseConnect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-        dbc,instring,length(instring),outstring,length(outstring),indicator) 
+        dbc,instring,length(instring),outstring,length(outstring),indicator)
     @unix_only ret = ccall( (:SQLBrowseConnect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-            dbc,instring,length(instring),outstring,length(outstring),indicator) 
+            dbc,instring,length(instring),outstring,length(outstring),indicator)
     return ret
 end
 #SQLDisconnect
@@ -455,27 +455,27 @@ end
  #Status:
 function SQLDisconnect(dbc::Ptr{Void})
     @windows_only ret = ccall( (:SQLDisconnect, odbc_dm), stdcall,
-        Int16, (Ptr{Void},), 
-        dbc) 
+        Int16, (Ptr{Void},),
+        dbc)
     @unix_only ret = ccall( (:SQLDisconnect, odbc_dm),
-            Int16, (Ptr{Void},), 
-            dbc) 
+            Int16, (Ptr{Void},),
+            dbc)
     return ret
 end
 #SQLGetFunctions
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms709291(v=vs.85).aspx
 #Descriptions:
 #Valid functionid
- 
+
 #supported will be SQL_TRUE or SQL_FALSE
 #Status:
 @compat function SQLGetFunctions(dbc::Ptr{Void},functionid::UInt16,supported::Array{UInt16,1})
     @windows_only ret = ccall( (:SQLGetFunctions, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Ptr{UInt16}),
-        dbc,functionid,supported) 
+        dbc,functionid,supported)
     @unix_only ret = ccall( (:SQLGetFunctions, odbc_dm),
             Int16, (Ptr{Void},UInt16,Ptr{UInt16}),
-            dbc,functionid,supported) 
+            dbc,functionid,supported)
     return ret
 end
 
@@ -486,14 +486,14 @@ end
 function SQLGetInfo{T,N}(dbc::Ptr{Void},attribute::Int,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetInfo, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-        dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+        dbc,attribute,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetInfo, odbc_dm),
             Int16, (Ptr{Void},Int,Ptr{T},Int,Ptr{Int}),
-            dbc,attribute,value,sizeof(T)*N,bytes_returned) 
+            dbc,attribute,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
-#### Query Functions #### 
+#### Query Functions ####
 #SQLNativeSql
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714575(v=vs.85).aspx
 #Description: returns the SQL string as modified by the driver
@@ -501,10 +501,10 @@ end
 function SQLNativeSql(dbc::Ptr{Void},query_string::String,output_string::Array{Uint8,1},length_ind::Array{Int,1})
     @windows_only ret = ccall( (:SQLNativeSql, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int,Ptr{Uint8},Int,Ptr{Int}),
-        dbc,query_string,sizeof(query_string),output_string,length(output_string),length_ind) 
+        dbc,query_string,sizeof(query_string),output_string,length(output_string),length_ind)
     @unix_only ret = ccall( (:SQLNativeSql, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int,Ptr{Uint8},Int,Ptr{Int}),
-            dbc,query_string,sizeof(query_string),output_string,length(output_string),length_ind) 
+            dbc,query_string,sizeof(query_string),output_string,length(output_string),length_ind)
     return ret
 end
 
@@ -512,15 +512,15 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714632(v=vs.85).aspx
 #Description:
 #valid sqltype
-#const SQL_ALL_TYPES = 
+#const SQL_ALL_TYPES =
 #Status:
 function SQLGetTypeInfo(stmt::Ptr{Void},sqltype::Int16)
     @windows_only ret = ccall( (:SQLGetTypeInfo, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16),
-        stmt,sqltype) 
+        stmt,sqltype)
     @unix_only ret = ccall( (:SQLGetTypeInfo, odbc_dm),
             Int16, (Ptr{Void},Int16),
-            stmt,sqltype) 
+            stmt,sqltype)
     return ret
 end
 
@@ -528,10 +528,10 @@ end
 function SQLPutData{T}(stmt::Ptr{Void},data::Array{T},data_length::Int)
     @windows_only ret = ccall( (:SQLPutData, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{T},Int),
-        stmt,data,data_length) 
+        stmt,data,data_length)
     @unix_only ret = ccall( (:SQLPutData, odbc_dm),
             Int16, (Ptr{Void},Ptr{T},Int),
-            stmt,data,data_length) 
+            stmt,data,data_length)
     return ret
 end
 
@@ -539,10 +539,10 @@ end
 function SQLPrepare(stmt::Ptr{Void},query_string::String)
     @windows_only ret = ccall( (:SQLPrepare, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16),
-        stmt,query_string,sizeof(query_string)) 
+        stmt,query_string,sizeof(query_string))
     @unix_only ret = ccall( (:SQLPrepare, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16),
-            stmt,query_string,sizeof(query_string)) 
+            stmt,query_string,sizeof(query_string))
     return ret
 end
 
@@ -550,10 +550,10 @@ end
 function SQLExecute(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLExecute, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLExecute, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
@@ -562,9 +562,9 @@ end
 #Description: executes a preparable statement
 #Status:
 function SQLExecDirect(stmt::Ptr{Void},query::String)
-    @windows_only ret = ccall( (:SQLExecDirect, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLExecDirect, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int),
-        stmt,query,sizeof(query)) 
+        stmt,query,sizeof(query))
     @unix_only ret = ccall( (:SQLExecDirect, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int),
             stmt,query,sizeof(query))
@@ -575,33 +575,33 @@ end
 function SQLCancel(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLCancel, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLCancel, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
-#### Resultset Metadata Functions #### 
+#### Resultset Metadata Functions ####
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms715393(v=vs.85).aspx
 function SQLNumResultCols(stmt::Ptr{Void},cols::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLNumResultCols, odbc_dm), stdcall,  
-        Int16, (Ptr{Void},Ptr{Int16}), 
-        stmt, cols) 
+    @windows_only ret = ccall( (:SQLNumResultCols, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Ptr{Int16}),
+        stmt, cols)
     @unix_only ret = ccall( (:SQLNumResultCols, odbc_dm),
-            Int16, (Ptr{Void},Ptr{Int16}), 
-            stmt, cols) 
+            Int16, (Ptr{Void},Ptr{Int16}),
+            stmt, cols)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711835(v=vs.85).aspx
 function SQLRowCount(stmt::Ptr{Void},rows::Array{Int,1})
-    @windows_only ret = ccall( (:SQLRowCount, odbc_dm), stdcall,  
-        Int16, (Ptr{Void},Ptr{Int}), 
-        stmt, rows) 
+    @windows_only ret = ccall( (:SQLRowCount, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Ptr{Int}),
+        stmt, rows)
     @unix_only ret = ccall( (:SQLRowCount, odbc_dm),
-            Int16, (Ptr{Void},Ptr{Int}), 
-            stmt, rows) 
+            Int16, (Ptr{Void},Ptr{Int}),
+            stmt, rows)
     return ret
 end
 
@@ -609,21 +609,21 @@ end
 function SQLColAttribute(stmt::Ptr{Void},x::Int,)
     @windows_only ret = ccall( (:SQLColAttribute, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,UInt16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
-        stmt,x,) 
+        stmt,x,)
     @unix_only ret = ccall( (:SQLColAttribute, odbc_dm),
             Int16, (Ptr{Void},UInt16,UInt16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
-            stmt,x,) 
+            stmt,x,)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716289(v=vs.85).aspx
 function SQLDescribeCol(stmt::Ptr{Void},x::Int,column_name::Array{Uint8,1},name_length::Array{Int16,1},datatype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLDescribeCol, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLDescribeCol, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-        stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable) 
+        stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable)
     @unix_only ret = ccall( (:SQLDescribeCol, odbc_dm),
             Int16, (Ptr{Void},UInt16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-            stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable) 
+            stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable)
     return ret
 end
 
@@ -631,10 +631,10 @@ end
 @compat function SQLDescribeParam(stmt::Ptr{Void},x::Int,sqltype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
     @windows_only ret = ccall( (:SQLDescribeParam, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-        stmt,x,sqltype,column_size,decimal_digits,nullable) 
+        stmt,x,sqltype,column_size,decimal_digits,nullable)
     @unix_only ret = ccall( (:SQLDescribeParam, odbc_dm),
             Int16, (Ptr{Void},UInt16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
-            stmt,x,sqltype,column_size,decimal_digits,nullable) 
+            stmt,x,sqltype,column_size,decimal_digits,nullable)
     return ret
 end
 
@@ -642,10 +642,10 @@ end
 function SQLParamData(stmt::Ptr{Void},ptr_buffer::Array{Ptr{Void},1})
     @windows_only ret = ccall( (:SQLParamData, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Void}),
-        stmt,ptr_buffer) 
+        stmt,ptr_buffer)
     @unix_only ret = ccall( (:SQLParamData, odbc_dm),
             Int16, (Ptr{Void},Ptr{Void}),
-            stmt,ptr_buffer) 
+            stmt,ptr_buffer)
     return ret
 end
 
@@ -653,53 +653,53 @@ end
 function SQLNumParams(stmt::Ptr{Void},param_count::Array{Int16,1})
     @windows_only ret = ccall( (:SQLNumParams, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Int16}),
-        stmt,param_count) 
+        stmt,param_count)
     @unix_only ret = ccall( (:SQLNumParams, odbc_dm),
             Int16, (Ptr{Void},Ptr{Int16}),
-            stmt,param_count) 
+            stmt,param_count)
     return ret
 end
 
-#### Resultset Retrieval Functions #### 
+#### Resultset Retrieval Functions ####
 #SQLBindParameter
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710963(v=vs.85).aspx
 #Description:
 #valid iotype
-@compat const SQL_PARAM_INPUT = Int16(1) 
-@compat const SQL_PARAM_OUTPUT = Int16(4) 
-@compat const SQL_PARAM_INPUT_OUTPUT = Int16(2) 
-#@compat const SQL_PARAM_INPUT_OUTPUT_STREAM = Int16() 
-#@compat const SQL_PARAM_OUTPUT_STREAM = Int16() 
+@compat const SQL_PARAM_INPUT = Int16(1)
+@compat const SQL_PARAM_OUTPUT = Int16(4)
+@compat const SQL_PARAM_INPUT_OUTPUT = Int16(2)
+#@compat const SQL_PARAM_INPUT_OUTPUT_STREAM = Int16()
+#@compat const SQL_PARAM_OUTPUT_STREAM = Int16()
 #Status:
 @compat function SQLBindParameter{T}(stmt::Ptr{Void},x::Int,iotype::Int16,ctype::Int16,sqltype::Int16,column_size::Int,decimal_digits::Int,param_value::Array{T},param_size::Int)
     @windows_only ret = ccall( (:SQLBindParameter, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
-        stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL) 
+        stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL)
     @unix_only ret = ccall( (:SQLBindParameter, odbc_dm),
             Int16, (Ptr{Void},UInt16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
-            stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL) 
+            stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL)
     return ret
 end
 SQLSetParam = SQLBindParameter
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711010(v=vs.85).aspx
 @compat function SQLBindCols{T,N}(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{T,N},jlsize::Int,indicator::Array{Int,1})
-    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
-        stmt,x,ctype,holder,jlsize,indicator) 
+        stmt,x,ctype,holder,jlsize,indicator)
     @unix_only ret = ccall( (:SQLBindCol, odbc_dm),
             Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
-            stmt,x,ctype,holder,jlsize,indicator) 
+            stmt,x,ctype,holder,jlsize,indicator)
     return ret
 end
 
 @compat function SQLBindCols(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{UTF8String,1},jlsize::Int,indicator::Array{Int,1})
-    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Int16,Ptr{Uint8},Int,Ptr{Int}),
-        stmt,x,ctype,holder,jlsize,indicator) 
+        stmt,x,ctype,holder,jlsize,indicator)
     @unix_only ret = ccall( (:SQLBindCol, odbc_dm),
             Int16, (Ptr{Void},UInt16,Int16,Ptr{Uint8},Int,Ptr{Int}),
-            stmt,x,ctype,holder,jlsize,indicator) 
+            stmt,x,ctype,holder,jlsize,indicator)
     return ret
 end
 
@@ -707,10 +707,10 @@ end
 function SQLSetCursorName(stmt::Ptr{Void},cursor::String)
     @windows_only ret = ccall( (:SQLSetCursorName, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16),
-        stmt,cursor,length(cursor)) 
+        stmt,cursor,length(cursor))
     @unix_only ret = ccall( (:SQLSetCursorName, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16),
-            stmt,cursor,length(cursor)) 
+            stmt,cursor,length(cursor))
     return ret
 end
 
@@ -718,10 +718,10 @@ end
 function SQLGetCursorName(stmt::Ptr{Void},cursor::Array{Uint8,1},cursor_length::Array{Int16,1})
     @windows_only ret = ccall( (:SQLGetCursorName, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Int16}),
-        stmt,cursor,length(cursor),cursor_length) 
+        stmt,cursor,length(cursor),cursor_length)
     @unix_only ret = ccall( (:SQLGetCursorName, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Int16}),
-            stmt,cursor,length(cursor),cursor_length) 
+            stmt,cursor,length(cursor),cursor_length)
     return ret
 end
 
@@ -729,10 +729,10 @@ end
 @compat function SQLGetData{T,N}(stmt::Ptr{Void},i::Int,ctype::Int16,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetData, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
-        stmt,i,ctype,value,sizeof(T)*N,bytes_returned) 
+        stmt,i,ctype,value,sizeof(T)*N,bytes_returned)
     @unix_only ret = ccall( (:SQLGetData, odbc_dm),
             Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
-            stmt,i,ctype,value,sizeof(T)*N,bytes_returned) 
+            stmt,i,ctype,value,sizeof(T)*N,bytes_returned)
     return ret
 end
 
@@ -749,12 +749,12 @@ end
 @compat const SQL_FETCH_BOOKMARK = Int16(8)
 #Status:
 function SQLFetchScroll(stmt::Ptr{Void},fetch_orientation::Int16,fetch_offset::Int)
-    @windows_only ret = ccall( (:SQLFetchScroll, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Int16,Int), 
-        stmt,fetch_orientation,fetch_offset) 
+    @windows_only ret = ccall( (:SQLFetchScroll, odbc_dm), stdcall,
+        Int16, (Ptr{Void},Int16,Int),
+        stmt,fetch_orientation,fetch_offset)
     @unix_only ret = ccall( (:SQLFetchScroll, odbc_dm),
-            Int16, (Ptr{Void},Int16,Int), 
-            stmt,fetch_orientation,fetch_offset) 
+            Int16, (Ptr{Void},Int16,Int),
+            stmt,fetch_orientation,fetch_offset)
     return ret
 end
 
@@ -762,10 +762,10 @@ end
 @compat function SQLExtendedFetch(stmt::Ptr{Void},fetch_orientation::UInt16,fetch_offset::Int,row_count_ptr::Array{Int,1},row_status_array::Array{Int16,1})
     @windows_only ret = ccall( (:SQLExtendedFetch, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16,Int,Ptr{Int},Ptr{Int16}),
-        stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array) 
+        stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array)
     @unix_only ret = ccall( (:SQLExtendedFetch, odbc_dm),
             Int16, (Ptr{Void},UInt16,Int,Ptr{Int},Ptr{Int16}),
-            stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array) 
+            stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array)
     return ret
 end
 
@@ -785,10 +785,10 @@ end
 @compat function SQLSetPos{T}(stmt::Ptr{Void},rownumber::T,operation::UInt16,lock_type::UInt16)
     @windows_only ret = ccall( (:SQLSetPos, odbc_dm), stdcall,
         Int16, (Ptr{Void},T,UInt16,UInt16),
-        stmt,rownumber,operation,lock_type) 
+        stmt,rownumber,operation,lock_type)
     @unix_only ret = ccall( (:SQLSetPos, odbc_dm),
             Int16, (Ptr{Void},T,UInt16,UInt16),
-            stmt,rownumber,operation,lock_type) 
+            stmt,rownumber,operation,lock_type)
     return ret
 end #T can be Uint64 or UInt16 it seems
 
@@ -796,10 +796,10 @@ end #T can be Uint64 or UInt16 it seems
 function SQLMoreResults(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLMoreResults, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLMoreResults, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
@@ -813,10 +813,10 @@ end
 function SQLEndTran(handletype::Int16,handle::Ptr{Void},completion_type::Int16)
     @windows_only ret = ccall( (:SQLEndTran, odbc_dm), stdcall,
         Int16, (Int16,Ptr{Void},Int16),
-        handletype,handle,completion_type) 
+        handletype,handle,completion_type)
     @unix_only ret = ccall( (:SQLEndTran, odbc_dm),
             Int16, (Int16,Ptr{Void},Int16),
-            handletype,handle,completion_type) 
+            handletype,handle,completion_type)
     return ret
 end
 
@@ -824,10 +824,10 @@ end
 function SQLCloseCursor(stmt::Ptr{Void})
     @windows_only ret = ccall( (:SQLCloseCursor, odbc_dm), stdcall,
         Int16, (Ptr{Void},),
-        stmt) 
+        stmt)
     @unix_only ret = ccall( (:SQLCloseCursor, odbc_dm),
             Int16, (Ptr{Void},),
-            stmt) 
+            stmt)
     return ret
 end
 
@@ -843,22 +843,22 @@ end
 @compat function SQLBulkOperations(stmt::Ptr{Void},operation::UInt16)
     @windows_only ret = ccall( (:SQLBulkOperations, odbc_dm), stdcall,
         Int16, (Ptr{Void},UInt16),
-        stmt,operation) 
+        stmt,operation)
     @unix_only ret = ccall( (:SQLBulkOperations, odbc_dm),
             Int16, (Ptr{Void},UInt16),
-            stmt,operation) 
+            stmt,operation)
     return ret
 end
 
-#### DBMS Meta Functions #### 
+#### DBMS Meta Functions ####
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711683(v=vs.85).aspx
 function SQLColumns(stmt::Ptr{Void},catalog::String,schema::String,table::String,column::String)
     @windows_only ret = ccall( (:SQLColumnPrivileges, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+        stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column))
     @unix_only ret = ccall( (:SQLColumnPrivileges, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+            stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column))
     return ret
 end
 
@@ -866,10 +866,10 @@ end
 function SQLColumnPrivileges(stmt::Ptr{Void},catalog::String,schema::String,table::String,column::String)
     @windows_only ret = ccall( (:SQLColumnPrivileges, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+        stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column))
     @unix_only ret = ccall( (:SQLColumnPrivileges, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column)) 
+            stmt,catalog,length(catalog),schema,length(schema),table,length(table),column,length(column))
     return ret
 end
 
@@ -877,10 +877,10 @@ end
 function SQLForeignKeys(stmt::Ptr{Void},pkcatalog::String,pkschema::String,pktable::String,fkcatalog::String,fkschema::String,fktable::String)
     @windows_only ret = ccall( (:SQLForeignKeys, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,pkcatalog,length(pkcatalog),pkschema,length(pkschema),pktable,length(pktable),fkcatalog,length(fkcatalog),fkschema,length(fkschema),fktable,length(fktable)) 
+        stmt,pkcatalog,length(pkcatalog),pkschema,length(pkschema),pktable,length(pktable),fkcatalog,length(fkcatalog),fkschema,length(fkschema),fktable,length(fktable))
     @unix_only ret = ccall( (:SQLForeignKeys, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,pkcatalog,length(pkcatalog),pkschema,length(pkschema),pktable,length(pktable),fkcatalog,length(fkcatalog),fkschema,length(fkschema),fktable,length(fktable)) 
+            stmt,pkcatalog,length(pkcatalog),pkschema,length(pkschema),pktable,length(pktable),fkcatalog,length(fkcatalog),fkschema,length(fkschema),fktable,length(fktable))
     return ret
 end
 
@@ -888,10 +888,10 @@ end
 function SQLPrimaryKeys(stmt::Ptr{Void},catalog::String,schema::String,table::String)
     @windows_only ret = ccall( (:SQLPrimaryKeys, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+        stmt,catalog,length(catalog),schema,length(schema),table,length(table))
     @unix_only ret = ccall( (:SQLPrimaryKeys, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+            stmt,catalog,length(catalog),schema,length(schema),table,length(table))
     return ret
 end
 
@@ -899,10 +899,10 @@ end
 function SQLProcedureColumns(stmt::Ptr{Void},catalog::String,schema::String,proc::String,column::String)
     @windows_only ret = ccall( (:SQLProcedureColumns, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),proc,length(proc),column,length(column)) 
+        stmt,catalog,length(catalog),schema,length(schema),proc,length(proc),column,length(column))
     @unix_only ret = ccall( (:SQLProcedureColumns, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),proc,length(proc),column,length(column)) 
+            stmt,catalog,length(catalog),schema,length(schema),proc,length(proc),column,length(column))
     return ret
 end
 
@@ -910,10 +910,10 @@ end
 function SQLProcedures(stmt::Ptr{Void},catalog::String,schema::String,proc::String)
     @windows_only ret = ccall( (:SQLProcedures, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),proc,length(proc)) 
+        stmt,catalog,length(catalog),schema,length(schema),proc,length(proc))
     @unix_only ret = ccall( (:SQLProcedures, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),proc,length(proc)) 
+            stmt,catalog,length(catalog),schema,length(schema),proc,length(proc))
     return ret
 end
 
@@ -921,10 +921,10 @@ end
 function SQLTables(stmt::Ptr{Void},catalog::String,schema::String,table::String,table_type::String)
     @windows_only ret = ccall( (:SQLTables, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),table_type,length(table_type)) 
+        stmt,catalog,length(catalog),schema,length(schema),table,length(table),table_type,length(table_type))
     @unix_only ret = ccall( (:SQLTables, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),table_type,length(table_type)) 
+            stmt,catalog,length(catalog),schema,length(schema),table,length(table),table_type,length(table_type))
     return ret
 end
 
@@ -932,10 +932,10 @@ end
 function SQLTablePrivileges(stmt::Ptr{Void},catalog::String,schema::String,table::String)
     @windows_only ret = ccall( (:SQLTablePrivileges, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+        stmt,catalog,length(catalog),schema,length(schema),table,length(table))
     @unix_only ret = ccall( (:SQLTablePrivileges, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table)) 
+            stmt,catalog,length(catalog),schema,length(schema),table,length(table))
     return ret
 end
 
@@ -943,22 +943,22 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711022(v=vs.85).aspx
 #Description:
 #valid unique
-@compat const SQL_INDEX_ALL = UInt16(1) 
-@compat const SQL_INDEX_CLUSTERED = UInt16(1) 
-@compat const SQL_INDEX_HASHED = UInt16(2) 
-@compat const SQL_INDEX_OTHER = UInt16(3) 
+@compat const SQL_INDEX_ALL = UInt16(1)
+@compat const SQL_INDEX_CLUSTERED = UInt16(1)
+@compat const SQL_INDEX_HASHED = UInt16(2)
+@compat const SQL_INDEX_OTHER = UInt16(3)
 @compat const SQL_INDEX_UNIQUE = UInt16(0)
 #valid reserved
-@compat const SQL_ENSURE = UInt16(1) 
-@compat const SQL_QUICK = UInt16(0) 
+@compat const SQL_ENSURE = UInt16(1)
+@compat const SQL_QUICK = UInt16(0)
 #Status:
 @compat function SQLStatistics(stmt::Ptr{Void},catalog::String,schema::String,table::String,unique::UInt16,reserved::UInt16)
     @windows_only ret = ccall( (:SQLStatistics, odbc_dm), stdcall,
         Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,UInt16,UInt16),
-        stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved) 
+        stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved)
     @unix_only ret = ccall( (:SQLStatistics, odbc_dm),
             Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,UInt16,UInt16),
-            stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved) 
+            stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved)
     return ret
 end
 
@@ -980,33 +980,33 @@ end
 function SQLSpecialColumns(stmt::Ptr{Void},id_type::Int16,catalog::String,schema::String,table::String,scope::Int16,nullable::Int16)
     @windows_only ret = ccall( (:SQLSpecialColumns, odbc_dm), stdcall,
         Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Int16,Int16),
-        stmt,id_type,catalog,length(catalog),schema,length(schema),table,length(table),scope,nullable) 
+        stmt,id_type,catalog,length(catalog),schema,length(schema),table,length(table),scope,nullable)
     @unix_only ret = ccall( (:SQLSpecialColumns, odbc_dm),
             Int16, (Ptr{Void},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Int16,Int16),
-            stmt,id_type,catalog,length(catalog),schema,length(schema),table,length(table),scope,nullable) 
+            stmt,id_type,catalog,length(catalog),schema,length(schema),table,length(table),scope,nullable)
     return ret
 end
 
-#### Error Handling Functions #### 
-#TODO: add consts 
+#### Error Handling Functions ####
+#TODO: add consts
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710181(v=vs.85).aspx
 function SQLGetDiagField(handletype::Int16,handle::Ptr{Void},i::Int16,diag_id::Int16,diag_info::Array{Uint,1},buffer_length::Int16,diag_length::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLGetDiagField, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLGetDiagField, odbc_dm), stdcall,
         Int16, (Int16,Ptr{Void},Int16,Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-        handletype,handle,i,diag_id,diag_info,buffer_length,msg_length) 
+        handletype,handle,i,diag_id,diag_info,buffer_length,msg_length)
     @unix_only ret = ccall( (:SQLGetDiagField, odbc_dm),
             Int16, (Int16,Ptr{Void},Int16,Int16,Ptr{Uint8},Int16,Ptr{Int16}),
-            handletype,handle,i,diag_id,diag_info,buffer_length,msg_length) 
+            handletype,handle,i,diag_id,diag_info,buffer_length,msg_length)
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716256(v=vs.85).aspx
 function SQLGetDiagRec(handletype::Int16,handle::Ptr{Void},i::Int16,state::Array{Uint8,1},native::Array{Int,1},error_msg::Array{Uint8,1},msg_length::Array{Int16,1})
-    @windows_only ret = ccall( (:SQLGetDiagRec, odbc_dm), stdcall, 
+    @windows_only ret = ccall( (:SQLGetDiagRec, odbc_dm), stdcall,
         Int16, (Int16,Ptr{Void},Int16,Ptr{Uint8},Ptr{Int},Ptr{Uint8},Int16,Ptr{Int16}),
-        handletype,handle,i,state,native,error_msg,length(error_msg),msg_length) 
+        handletype,handle,i,state,native,error_msg,length(error_msg),msg_length)
     @unix_only ret = ccall( (:SQLGetDiagRec, odbc_dm),
             Int16, (Int16,Ptr{Void},Int16,Ptr{Uint8},Ptr{Int},Ptr{Uint8},Int16,Ptr{Int16}),
-            handletype,handle,i,state,native,error_msg,length(error_msg),msg_length) 
+            handletype,handle,i,state,native,error_msg,length(error_msg),msg_length)
     return ret
 end

--- a/src/ODBC_API.jl
+++ b/src/ODBC_API.jl
@@ -28,21 +28,21 @@
 const MULTIROWFETCH = 65535 
 
 # success codes
-const SQL_SUCCESS           = int16(0)
-const SQL_SUCCESS_WITH_INFO = int16(1)
+@compat const SQL_SUCCESS           = Int16(0)
+@compat const SQL_SUCCESS_WITH_INFO = Int16(1)
 
 # error codes
-const SQL_ERROR             = int16(-1)
-const SQL_INVALID_HANDLE    = int16(-2)
+@compat const SQL_ERROR             = Int16(-1)
+@compat const SQL_INVALID_HANDLE    = Int16(-2)
 
 # status codes
-const SQL_STILL_EXECUTING   = int16(2)
-const SQL_NO_DATA           = int16(100)
+@compat const SQL_STILL_EXECUTING   = Int16(2)
+@compat const SQL_NO_DATA           = Int16(100)
 
-const RETURN_VALUES = [SQL_ERROR   => "SQL_ERROR",
-                       SQL_NO_DATA => "SQL_NO_DATA",
-                       SQL_INVALID_HANDLE  => "SQL_INVALID_HANDLE",
-                       SQL_STILL_EXECUTING => "SQL_STILL_EXECUTING"]
+@compat const RETURN_VALUES = Dict(SQL_ERROR   => "SQL_ERROR",
+                           SQL_NO_DATA => "SQL_NO_DATA",
+                           SQL_INVALID_HANDLE  => "SQL_INVALID_HANDLE",
+                           SQL_STILL_EXECUTING => "SQL_STILL_EXECUTING")
 
 #Macros to to check if a function returned a success value or not; used with 'if' statements
 #e.g. if @SUCCEEDED SQLDisconnect(dbc) print("Disconnected successfully") end
@@ -113,10 +113,10 @@ end
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms712455(v=vs.85).aspx
 # Description: allocates an environment, connection, statement, or descriptor handle
 # Valid handle types
-const SQL_HANDLE_ENV  = int16(1)  
-const SQL_HANDLE_DBC  = int16(2) 
-const SQL_HANDLE_STMT = int16(3)
-const SQL_HANDLE_DESC = int16(4)
+@compat const SQL_HANDLE_ENV  = Int16(1)
+@compat const SQL_HANDLE_DBC  = Int16(2)
+@compat const SQL_HANDLE_STMT = Int16(3)
+@compat const SQL_HANDLE_DESC = Int16(4)
 const SQL_NULL_HANDLE = C_NULL
 
 #Status: Tested on Windows, Linux, Mac 32/64-bit
@@ -156,13 +156,13 @@ end
 # Description: sets attributes that govern aspects of environments
 # Valid attributes; valid values for attribute are indented
 const SQL_ATTR_CONNECTION_POOLING = 201
-const SQL_CP_OFF = uint(0)
-const SQL_CP_ONE_PER_DRIVER = uint(1)
-const SQL_CP_ONE_PER_HENV = uint(2)
+@compat const SQL_CP_OFF = UInt(0)
+@compat const SQL_CP_ONE_PER_DRIVER = UInt(1)
+@compat const SQL_CP_ONE_PER_HENV = UInt(2)
 const SQL_CP_DEFAULT = SQL_CP_OFF
 const SQL_ATTR_CP_MATCH = 202
-const SQL_CP_RELAXED_MATCH = uint(1)
-const SQL_CP_STRICT_MATCH = uint(0)
+@compat const SQL_CP_RELAXED_MATCH = UInt(1)
+@compat const SQL_CP_STRICT_MATCH = UInt(0)
 const SQL_ATTR_ODBC_VERSION = 200
 const SQL_OV_ODBC2 = 2
 const SQL_OV_ODBC3 = 3 
@@ -207,23 +207,23 @@ end
 # Description: sets attributes that govern aspects of connections.
 # Valid attributes
 const SQL_ATTR_ACCESS_MODE = 101
-const SQL_MODE_READ_ONLY = uint(1)
-const SQL_MODE_READ_WRITE = uint(0)
+@compat const SQL_MODE_READ_ONLY = UInt(1)
+@compat const SQL_MODE_READ_WRITE = UInt(0)
 #const SQL_ATTR_ASYNC_DBC_EVENT 
 #pointer
 #const SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE 
-#const SQL_ASYNC_DBC_ENABLE_ON = uint()
-#const SQL_ASYNC_DBC_ENABLE_OFF = uint()
+#@compat const SQL_ASYNC_DBC_ENABLE_ON = UInt()
+#@compat const SQL_ASYNC_DBC_ENABLE_OFF = UInt()
 #const SQL_ATTR_ASYNC_DBC_PCALLBACK 
 #pointer
 #const SQL_ATTR_ASYNC_DBC_PCONTEXT 
 #pointer
 const SQL_ATTR_ASYNC_ENABLE = 4
-const SQL_ASYNC_ENABLE_OFF = uint(0)
-const SQL_ASYNC_ENABLE_ON = uint(1)
+@compat const SQL_ASYNC_ENABLE_OFF = UInt(0)
+@compat const SQL_ASYNC_ENABLE_ON = UInt(1)
 const SQL_ATTR_AUTOCOMMIT = 102
-const SQL_AUTOCOMMIT_OFF = uint(0)
-const SQL_AUTOCOMMIT_ON = uint(1)
+@compat const SQL_AUTOCOMMIT_OFF = UInt(0)
+@compat const SQL_AUTOCOMMIT_ON = UInt(1)
 const SQL_ATTR_CONNECTION_TIMEOUT = 113
 #uint of how long you want the connection timeout
 const SQL_ATTR_CURRENT_CATALOG = 109
@@ -238,16 +238,16 @@ const SQL_ATTR_LOGIN_TIMEOUT = 103
 const SQL_ATTR_METADATA_ID = 10014
 #SQL_TRUE, SQL_FALSE
 const SQL_ATTR_ODBC_CURSORS = 110
-const SQL_CUR_USE_IF_NEEDED = uint(0)
-const SQL_CUR_USE_ODBC = uint(1)
-const SQL_CUR_USE_DRIVER = uint(2)
+@compat const SQL_CUR_USE_IF_NEEDED = UInt(0)
+@compat const SQL_CUR_USE_ODBC = UInt(1)
+@compat const SQL_CUR_USE_DRIVER = UInt(2)
 const SQL_ATTR_PACKET_SIZE = 112
 #uint for network packet size
 const SQL_ATTR_QUIET_MODE = 111
 #window handle pointer
 const SQL_ATTR_TRACE = 104
-const SQL_OPT_TRACE_OFF = uint(0)
-const SQL_OPT_TRACE_ON = uint(1)
+@compat const SQL_OPT_TRACE_OFF = UInt(0)
+@compat const SQL_OPT_TRACE_ON = UInt(1)
 const SQL_ATTR_TRACEFILE = 105
 #A null-terminated character string containing the name of the trace file.
 const SQL_ATTR_TRANSLATE_LIB = 106
@@ -344,17 +344,17 @@ end
 # discards pending results, or, optionally, 
 # frees all resources associated with the statement handle.
 #Valid param
-const SQL_CLOSE = uint16(0)
-const SQL_RESET_PARAMS = uint16(3)
-const SQL_UNBIND = uint16(2)
+@compat const SQL_CLOSE = UInt16(0)
+@compat const SQL_RESET_PARAMS = UInt16(3)
+@compat const SQL_UNBIND = UInt16(2)
 
 #Status:
-function SQLFreeStmt(stmt::Ptr{Void},param::Uint16)
+@compat function SQLFreeStmt(stmt::Ptr{Void},param::UInt16)
     @windows_only ret = ccall( (:SQLFreeStmt, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Uint16), 
+        Int16, (Ptr{Void},UInt16), 
         stmt, param) 
     @unix_only ret = ccall( (:SQLFreeStmt, odbc_dm),
-            Int16, (Ptr{Void},Uint16), 
+            Int16, (Ptr{Void},UInt16), 
             stmt, param) 
     return ret
 end
@@ -422,17 +422,17 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms715433(v=vs.85).aspx
 #Description:
 #Valid driver_prompt
-const SQL_DRIVER_COMPLETE = uint16(1)
-const SQL_DRIVER_COMPLETE_REQUIRED = uint16(3)
-const SQL_DRIVER_NOPROMPT = uint16(0)
-const SQL_DRIVER_PROMPT = uint16(2)
+@compat const SQL_DRIVER_COMPLETE = UInt16(1)
+@compat const SQL_DRIVER_COMPLETE_REQUIRED = UInt16(3)
+@compat const SQL_DRIVER_NOPROMPT = UInt16(0)
+@compat const SQL_DRIVER_PROMPT = UInt16(2)
 #Status:
-function SQLDriverConnect(dbc::Ptr{Void},window_handle::Ptr{Void},conn_string::String,out_conn::Ptr{Void},out_buff::Array{Int16,1},driver_prompt::Uint16)
+@compat function SQLDriverConnect(dbc::Ptr{Void},window_handle::Ptr{Void},conn_string::String,out_conn::Ptr{Void},out_buff::Array{Int16,1},driver_prompt::UInt16)
     @windows_only ret = ccall( (:SQLDriverConnect, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},Uint16),
+        Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},UInt16),
         dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt) 
     @unix_only ret = ccall( (:SQLDriverConnect, odbc_dm),
-            Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},Uint16),
+            Int16, (Ptr{Void},Ptr{Void},Ptr{Uint8},Int16,Ptr{Void},Int16,Ptr{Int16},UInt16),
             dbc,window_handle,conn_string,length(conn_string),out_conn,0,out_buff,driver_prompt) 
     return ret
 end
@@ -469,12 +469,12 @@ end
  
 #supported will be SQL_TRUE or SQL_FALSE
 #Status:
-function SQLGetFunctions(dbc::Ptr{Void},functionid::Uint16,supported::Array{Uint16,1})
+@compat function SQLGetFunctions(dbc::Ptr{Void},functionid::UInt16,supported::Array{UInt16,1})
     @windows_only ret = ccall( (:SQLGetFunctions, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16,Ptr{Uint16}),
+        Int16, (Ptr{Void},UInt16,Ptr{UInt16}),
         dbc,functionid,supported) 
     @unix_only ret = ccall( (:SQLGetFunctions, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Ptr{Uint16}),
+            Int16, (Ptr{Void},UInt16,Ptr{UInt16}),
             dbc,functionid,supported) 
     return ret
 end
@@ -608,10 +608,10 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms713558(v=vs.85).aspx
 function SQLColAttribute(stmt::Ptr{Void},x::Int,)
     @windows_only ret = ccall( (:SQLColAttribute, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16,Uint16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
+        Int16, (Ptr{Void},UInt16,UInt16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
         stmt,x,) 
     @unix_only ret = ccall( (:SQLColAttribute, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Uint16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
+            Int16, (Ptr{Void},UInt16,UInt16,Ptr,Int16,Ptr{Int16},Ptr{Int}),
             stmt,x,) 
     return ret
 end
@@ -619,21 +619,21 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716289(v=vs.85).aspx
 function SQLDescribeCol(stmt::Ptr{Void},x::Int,column_name::Array{Uint8,1},name_length::Array{Int16,1},datatype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
     @windows_only ret = ccall( (:SQLDescribeCol, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Uint16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
+        Int16, (Ptr{Void},UInt16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
         stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable) 
     @unix_only ret = ccall( (:SQLDescribeCol, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
+            Int16, (Ptr{Void},UInt16,Ptr{Uint8},Int16,Ptr{Int16},Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
             stmt,x,column_name,length(column_name),name_length,datatype,column_size,decimal_digits,nullable) 
     return ret
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710188(v=vs.85).aspx
-function SQLDescribeParam(stmt::Ptr{Void},x::Int,sqltype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
+@compat function SQLDescribeParam(stmt::Ptr{Void},x::Int,sqltype::Array{Int16,1},column_size::Array{Int,1},decimal_digits::Array{Int16,1},nullable::Array{Int16,1})
     @windows_only ret = ccall( (:SQLDescribeParam, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
+        Int16, (Ptr{Void},UInt16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
         stmt,x,sqltype,column_size,decimal_digits,nullable) 
     @unix_only ret = ccall( (:SQLDescribeParam, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
+            Int16, (Ptr{Void},UInt16,Ptr{Int16},Ptr{Int},Ptr{Int16},Ptr{Int16}),
             stmt,x,sqltype,column_size,decimal_digits,nullable) 
     return ret
 end
@@ -665,40 +665,40 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms710963(v=vs.85).aspx
 #Description:
 #valid iotype
-const SQL_PARAM_INPUT = int16(1) 
-const SQL_PARAM_OUTPUT = int16(4) 
-const SQL_PARAM_INPUT_OUTPUT = int16(2) 
-#const SQL_PARAM_INPUT_OUTPUT_STREAM = int16() 
-#const SQL_PARAM_OUTPUT_STREAM = int16() 
+@compat const SQL_PARAM_INPUT = Int16(1) 
+@compat const SQL_PARAM_OUTPUT = Int16(4) 
+@compat const SQL_PARAM_INPUT_OUTPUT = Int16(2) 
+#@compat const SQL_PARAM_INPUT_OUTPUT_STREAM = Int16() 
+#@compat const SQL_PARAM_OUTPUT_STREAM = Int16() 
 #Status:
-function SQLBindParameter{T}(stmt::Ptr{Void},x::Int,iotype::Int16,ctype::Int16,sqltype::Int16,column_size::Int,decimal_digits::Int,param_value::Array{T},param_size::Int)
+@compat function SQLBindParameter{T}(stmt::Ptr{Void},x::Int,iotype::Int16,ctype::Int16,sqltype::Int16,column_size::Int,decimal_digits::Int,param_value::Array{T},param_size::Int)
     @windows_only ret = ccall( (:SQLBindParameter, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
+        Int16, (Ptr{Void},UInt16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
         stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL) 
     @unix_only ret = ccall( (:SQLBindParameter, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
+            Int16, (Ptr{Void},UInt16,Int16,Int16,Int16,Uint,Int16,Ptr{T},Int,Ptr{Void}),
             stmt,x,iotype,ctype,sqltype,column_size,decimal_digits,param_value,param_size,C_NULL) 
     return ret
 end
 SQLSetParam = SQLBindParameter
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711010(v=vs.85).aspx
-function SQLBindCols{T,N}(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{T,N},jlsize::Int,indicator::Array{Int,1})
+@compat function SQLBindCols{T,N}(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{T,N},jlsize::Int,indicator::Array{Int,1})
     @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
+        Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
         stmt,x,ctype,holder,jlsize,indicator) 
     @unix_only ret = ccall( (:SQLBindCol, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
+            Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
             stmt,x,ctype,holder,jlsize,indicator) 
     return ret
 end
 
-function SQLBindCols(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{UTF8String,1},jlsize::Int,indicator::Array{Int,1})
+@compat function SQLBindCols(stmt::Ptr{Void},x::Int,ctype::Int16,holder::Array{UTF8String,1},jlsize::Int,indicator::Array{Int,1})
     @windows_only ret = ccall( (:SQLBindCol, odbc_dm), stdcall, 
-        Int16, (Ptr{Void},Uint16,Int16,Ptr{Uint8},Int,Ptr{Int}),
+        Int16, (Ptr{Void},UInt16,Int16,Ptr{Uint8},Int,Ptr{Int}),
         stmt,x,ctype,holder,jlsize,indicator) 
     @unix_only ret = ccall( (:SQLBindCol, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Int16,Ptr{Uint8},Int,Ptr{Int}),
+            Int16, (Ptr{Void},UInt16,Int16,Ptr{Uint8},Int,Ptr{Int}),
             stmt,x,ctype,holder,jlsize,indicator) 
     return ret
 end
@@ -726,12 +726,12 @@ function SQLGetCursorName(stmt::Ptr{Void},cursor::Array{Uint8,1},cursor_length::
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms715441(v=vs.85).aspx
-function SQLGetData{T,N}(stmt::Ptr{Void},i::Int,ctype::Int16,value::Array{T,N},bytes_returned::Array{Int,1})
+@compat function SQLGetData{T,N}(stmt::Ptr{Void},i::Int,ctype::Int16,value::Array{T,N},bytes_returned::Array{Int,1})
     @windows_only ret = ccall( (:SQLGetData, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
+        Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
         stmt,i,ctype,value,sizeof(T)*N,bytes_returned) 
     @unix_only ret = ccall( (:SQLGetData, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Int16,Ptr{T},Int,Ptr{Int}),
+            Int16, (Ptr{Void},UInt16,Int16,Ptr{T},Int,Ptr{Int}),
             stmt,i,ctype,value,sizeof(T)*N,bytes_returned) 
     return ret
 end
@@ -740,13 +740,13 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714682(v=vs.85).aspx
 #Description:
 #valid fetch_orientation
-const SQL_FETCH_NEXT = int16(1)
-const SQL_FETCH_PRIOR = int16(4)
-const SQL_FETCH_FIRST = int16(2)
-const SQL_FETCH_LAST = int16(3)
-const SQL_FETCH_ABSOLUTE = int16(5)
-const SQL_FETCH_RELATIVE = int16(6)
-const SQL_FETCH_BOOKMARK = int16(8)
+@compat const SQL_FETCH_NEXT = Int16(1)
+@compat const SQL_FETCH_PRIOR = Int16(4)
+@compat const SQL_FETCH_FIRST = Int16(2)
+@compat const SQL_FETCH_LAST = Int16(3)
+@compat const SQL_FETCH_ABSOLUTE = Int16(5)
+@compat const SQL_FETCH_RELATIVE = Int16(6)
+@compat const SQL_FETCH_BOOKMARK = Int16(8)
 #Status:
 function SQLFetchScroll(stmt::Ptr{Void},fetch_orientation::Int16,fetch_offset::Int)
     @windows_only ret = ccall( (:SQLFetchScroll, odbc_dm), stdcall, 
@@ -759,12 +759,12 @@ function SQLFetchScroll(stmt::Ptr{Void},fetch_orientation::Int16,fetch_offset::I
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms713591(v=vs.85).aspx
-function SQLExtendedFetch(stmt::Ptr{Void},fetch_orientation::Uint16,fetch_offset::Int,row_count_ptr::Array{Int,1},row_status_array::Array{Int16,1})
+@compat function SQLExtendedFetch(stmt::Ptr{Void},fetch_orientation::UInt16,fetch_offset::Int,row_count_ptr::Array{Int,1},row_status_array::Array{Int16,1})
     @windows_only ret = ccall( (:SQLExtendedFetch, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16,Int,Ptr{Int},Ptr{Int16}),
+        Int16, (Ptr{Void},UInt16,Int,Ptr{Int},Ptr{Int16}),
         stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array) 
     @unix_only ret = ccall( (:SQLExtendedFetch, odbc_dm),
-            Int16, (Ptr{Void},Uint16,Int,Ptr{Int},Ptr{Int16}),
+            Int16, (Ptr{Void},UInt16,Int,Ptr{Int},Ptr{Int16}),
             stmt,fetch_orientation,fetch_offset,row_count_ptr,row_status_array) 
     return ret
 end
@@ -773,24 +773,24 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms713507(v=vs.85).aspx
 #Description:
 #valid operation
-const SQL_POSITION = uint16(0) #SQLSetPos
-const SQL_REFRESH = uint16(1) #SQLSetPos
-const SQL_UPDATE = uint16(2) #SQLSetPos
-const SQL_DELETE = uint16(3) #SQLSetPos
+@compat const SQL_POSITION = UInt16(0) #SQLSetPos
+@compat const SQL_REFRESH = UInt16(1) #SQLSetPos
+@compat const SQL_UPDATE = UInt16(2) #SQLSetPos
+@compat const SQL_DELETE = UInt16(3) #SQLSetPos
 #valid lock_type
-const SQL_LOCK_NO_CHANGE = uint16(0) #SQLSetPos
-const SQL_LOCK_EXCLUSIVE = uint16(1) #SQLSetPos
-const SQL_LOCK_UNLOCK = uint16(2) #SQLSetPos
+@compat const SQL_LOCK_NO_CHANGE = UInt16(0) #SQLSetPos
+@compat const SQL_LOCK_EXCLUSIVE = UInt16(1) #SQLSetPos
+@compat const SQL_LOCK_UNLOCK = UInt16(2) #SQLSetPos
 #Status
-function SQLSetPos{T}(stmt::Ptr{Void},rownumber::T,operation::Uint16,lock_type::Uint16)
+@compat function SQLSetPos{T}(stmt::Ptr{Void},rownumber::T,operation::UInt16,lock_type::UInt16)
     @windows_only ret = ccall( (:SQLSetPos, odbc_dm), stdcall,
-        Int16, (Ptr{Void},T,Uint16,Uint16),
+        Int16, (Ptr{Void},T,UInt16,UInt16),
         stmt,rownumber,operation,lock_type) 
     @unix_only ret = ccall( (:SQLSetPos, odbc_dm),
-            Int16, (Ptr{Void},T,Uint16,Uint16),
+            Int16, (Ptr{Void},T,UInt16,UInt16),
             stmt,rownumber,operation,lock_type) 
     return ret
-end #T can be Uint64 or Uint16 it seems
+end #T can be Uint64 or UInt16 it seems
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714673(v=vs.85).aspx
 function SQLMoreResults(stmt::Ptr{Void})
@@ -807,8 +807,8 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms716544(v=vs.85).aspx
 #Description:
 #valid completion_type
-const SQL_COMMIT = int16(0) #SQLEndTran
-const SQL_ROLLBACK = int16(1) #SQLEndTran
+@compat const SQL_COMMIT = Int16(0) #SQLEndTran
+@compat const SQL_ROLLBACK = Int16(1) #SQLEndTran
 #Status:
 function SQLEndTran(handletype::Int16,handle::Ptr{Void},completion_type::Int16)
     @windows_only ret = ccall( (:SQLEndTran, odbc_dm), stdcall,
@@ -835,17 +835,17 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms712471(v=vs.85).aspx
 #Description:
 #valid operation
-const SQL_ADD = uint16(4) #SQLBulkOperations
-const SQL_UPDATE_BY_BOOKMARK = uint16(5) #SQLBulkOperations
-const SQL_DELETE_BY_BOOKMARK = uint16(6) #SQLBulkOperations
-const SQL_FETCH_BY_BOOKMARK = uint16(7) #SQLBulkOperations
+@compat const SQL_ADD = UInt16(4) #SQLBulkOperations
+@compat const SQL_UPDATE_BY_BOOKMARK = UInt16(5) #SQLBulkOperations
+@compat const SQL_DELETE_BY_BOOKMARK = UInt16(6) #SQLBulkOperations
+@compat const SQL_FETCH_BY_BOOKMARK = UInt16(7) #SQLBulkOperations
 #Status:
-function SQLBulkOperations(stmt::Ptr{Void},operation::Uint16)
+@compat function SQLBulkOperations(stmt::Ptr{Void},operation::UInt16)
     @windows_only ret = ccall( (:SQLBulkOperations, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Uint16),
+        Int16, (Ptr{Void},UInt16),
         stmt,operation) 
     @unix_only ret = ccall( (:SQLBulkOperations, odbc_dm),
-            Int16, (Ptr{Void},Uint16),
+            Int16, (Ptr{Void},UInt16),
             stmt,operation) 
     return ret
 end
@@ -943,21 +943,21 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms711022(v=vs.85).aspx
 #Description:
 #valid unique
-const SQL_INDEX_ALL = uint16(1) 
-const SQL_INDEX_CLUSTERED = uint16(1) 
-const SQL_INDEX_HASHED = uint16(2) 
-const SQL_INDEX_OTHER = uint16(3) 
-const SQL_INDEX_UNIQUE = uint16(0)
+@compat const SQL_INDEX_ALL = UInt16(1) 
+@compat const SQL_INDEX_CLUSTERED = UInt16(1) 
+@compat const SQL_INDEX_HASHED = UInt16(2) 
+@compat const SQL_INDEX_OTHER = UInt16(3) 
+@compat const SQL_INDEX_UNIQUE = UInt16(0)
 #valid reserved
-const SQL_ENSURE = uint16(1) 
-const SQL_QUICK = uint16(0) 
+@compat const SQL_ENSURE = UInt16(1) 
+@compat const SQL_QUICK = UInt16(0) 
 #Status:
-function SQLStatistics(stmt::Ptr{Void},catalog::String,schema::String,table::String,unique::Uint16,reserved::Uint16)
+@compat function SQLStatistics(stmt::Ptr{Void},catalog::String,schema::String,table::String,unique::UInt16,reserved::UInt16)
     @windows_only ret = ccall( (:SQLStatistics, odbc_dm), stdcall,
-        Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Uint16,Uint16),
+        Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,UInt16,UInt16),
         stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved) 
     @unix_only ret = ccall( (:SQLStatistics, odbc_dm),
-            Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,Uint16,Uint16),
+            Int16, (Ptr{Void},Ptr{Uint8},Int16,Ptr{Uint8},Int16,Ptr{Uint8},Int16,UInt16,UInt16),
             stmt,catalog,length(catalog),schema,length(schema),table,length(table),unique,reserved) 
     return ret
 end
@@ -966,16 +966,16 @@ end
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms714602(v=vs.85).aspx
 #Description:
 #valid id_type
-const SQL_BEST_ROWID = int16(1) #SQLSpecialColumns
-const SQL_ROWVER = int16(2) #SQLSpecialColumns
+@compat const SQL_BEST_ROWID        = Int16(1) #SQLSpecialColumns
+@compat const SQL_ROWVER            = Int16(2) #SQLSpecialColumns
 #valid scope
-const SQL_SCOPE_CURROW = int16(0) #SQLSpecialColumns
-const SQL_SCOPE_SESSION = int16(2) #SQLSpecialColumns
-const SQL_SCOPE_TRANSACTION = int16(1) #SQLSpecialColumns
+@compat const SQL_SCOPE_CURROW      = Int16(0) #SQLSpecialColumns
+@compat const SQL_SCOPE_SESSION     = Int16(2) #SQLSpecialColumns
+@compat const SQL_SCOPE_TRANSACTION = Int16(1) #SQLSpecialColumns
 #valid nullable
-const SQL_NO_NULLS = int16(0) #SQLSpecialColumns
-const SQL_NULLABLE = int16(1) #SQLSpecialColumns
-#const SQL_NULLABLE_UNKNOWN = int16() #SQLSpecialColumns
+@compat const SQL_NO_NULLS          = Int16(0) #SQLSpecialColumns
+@compat const SQL_NULLABLE          = Int16(1) #SQLSpecialColumns
+#@compat const SQL_NULLABLE_UNKNOWN = Int16() #SQLSpecialColumns
 #Status:
 function SQLSpecialColumns(stmt::Ptr{Void},id_type::Int16,catalog::String,schema::String,table::String,scope::Int16,nullable::Int16)
     @windows_only ret = ccall( (:SQLSpecialColumns, odbc_dm), stdcall,

--- a/src/ODBC_Types.jl
+++ b/src/ODBC_Types.jl
@@ -7,7 +7,7 @@ let
         @windows_only lib_choices = ["odbc32"]
         @osx_only     lib_choices = ["libodbc.dylib","libiodbc","libiodbc.dylib","libiodbc.1.dylib","libiodbc.2.dylib","libiodbc.3.dylib"]
         local lib
-        for lib in lib_choices 
+        for lib in lib_choices
             try
                 @compat Libdl.dlopen(lib)
                 succeeded = true
@@ -161,7 +161,7 @@ end
 @compat const SQL_WCHAR         = Int16( -8) # Unicode character string of fixed string length n
 @compat const SQL_WVARCHAR      = Int16( -9) # Unicode variable-length character string with a maximum string length n
 @compat const SQL_WLONGVARCHAR  = Int16(-10) # Unicode variable-length character data. Maximum length is data source–dependent
-@compat const SQL_DECIMAL       = Int16(  3) 
+@compat const SQL_DECIMAL       = Int16(  3)
 @compat const SQL_NUMERIC       = Int16(  2)
 @compat const SQL_SMALLINT      = Int16(  5) # Exact numeric value with precision 5 and scale 0 (signed: –32,768 <= n <= 32,767, unsigned: 0 <= n <= 65,535)
 @compat const SQL_INTEGER       = Int16(  4) # Exact numeric value with precision 10 and scale 0 (signed: –2[31] <= n <= 2[31] – 1, unsigned: 0 <= n <= 2[32] – 1)
@@ -175,7 +175,7 @@ end
 @compat const SQL_VARBINARY     = Int16( -3) # Variable length binary data of maximum length n. The maximum is set by the user.
 @compat const SQL_LONGVARBINARY = Int16( -4) # Variable length binary data. Maximum length is data source–dependent.
 @compat const SQL_TYPE_DATE     = Int16( 91) # Year, month, and day fields, conforming to the rules of the Gregorian calendar.
-@compat const SQL_TYPE_TIME     = Int16( 92) # Hour, minute, and second fields, with valid values for hours of 00 to 23, 
+@compat const SQL_TYPE_TIME     = Int16( 92) # Hour, minute, and second fields, with valid values for hours of 00 to 23,
                                      # valid values for minutes of 00 to 59, and valid values for seconds of 00 to 61. Precision p indicates the seconds precision.
 @compat const SQL_TYPE_TIMESTAMP = Int16( 93) # Year, month, day, hour, minute, and second fields, with valid values as defined for the DATE and TIME data types.
 

--- a/src/ODBC_Types.jl
+++ b/src/ODBC_Types.jl
@@ -9,7 +9,7 @@ let
         local lib
         for lib in lib_choices 
             try
-                dlopen(lib)
+                @compat Libdl.dlopen(lib)
                 succeeded = true
                 break
             end
@@ -22,9 +22,9 @@ end
 # Translation of sqltypes.h; C typealiases for SQL functions
 # http://msdn.microsoft.com/en-us/library/windows/desktop/ms716298(v=vs.85).aspx
 # http://msdn.microsoft.com/en-us/library/windows/desktop/aa383751(v=vs.85).aspx
-typealias SQLCHAR       Uint8
-typealias SQLSCHAR      Uint8
-typealias SQLVARCHAR    Uint8
+@compat typealias SQLCHAR       UInt8
+@compat typealias SQLSCHAR      UInt8
+@compat typealias SQLVARCHAR    UInt8
 typealias SQLDECIMAL    Cdouble
 typealias SQLNUMERIC    Cdouble
 typealias SQLDOUBLE     Cdouble
@@ -38,15 +38,15 @@ typealias SQLTIME       Cuchar
 typealias SQLTIMESTAMP  Cuchar
 
 if contains(odbc_dm, "iodbc")
-    typealias SQLWCHAR Uint32
+    @compat typealias SQLWCHAR UInt32
 else
-    typealias SQLWCHAR Uint16
+    @compat typealias SQLWCHAR UInt16
 end
 
 if WORD_SIZE == 64
     typealias SQLLEN        Int64
-    typealias SQLULEN       Uint64
-    typealias SQLSETPOSIROW Uint64
+    @compat typealias SQLULEN       UInt64
+    @compat typealias SQLSETPOSIROW UInt64
 else
     typealias SQLLEN        SQLINTEGER
     typealias SQLULEN       SQLUINTEGER
@@ -117,14 +117,14 @@ end
 
 # SQL Data Type                     C Data Type                         Julia Type
 # ---------------------------------------------------------------------------------
-# SQL_CHAR                          SQL_C_CHAR                          Uint8
-# SQL_VARCHAR                       SQL_C_CHAR                          Uint8
-# SQL_LONGVARCHAR                   SQL_C_CHAR                          Uint8
-# SQL_WCHAR                         SQL_C_WCHAR                         Uint16
-# SQL_WVARCHAR                      SQL_C_WCHAR                         Uint16
-# SQL_WLONGVARCHAR                  SQL_C_WCHAR                         Uint16
-# SQL_DECIMAL                       SQL_C_DOUBLE                        Float64                                    
-# SQL_NUMERIC                       SQL_C_DOUBLE                        Float64                                    
+# SQL_CHAR                          SQL_C_CHAR                          UInt8
+# SQL_VARCHAR                       SQL_C_CHAR                          UInt8
+# SQL_LONGVARCHAR                   SQL_C_CHAR                          UInt8
+# SQL_WCHAR                         SQL_C_WCHAR                         UInt16
+# SQL_WVARCHAR                      SQL_C_WCHAR                         UInt16
+# SQL_WLONGVARCHAR                  SQL_C_WCHAR                         UInt16
+# SQL_DECIMAL                       SQL_C_DOUBLE                        Float64
+# SQL_NUMERIC                       SQL_C_DOUBLE                        Float64
 # SQL_SMALLINT                      SQL_C_SHORT                         Int16
 # SQL_INTEGER                       SQL_C_LONG                          Int32
 # SQL_REAL                          SQL_C_FLOAT                         Float64
@@ -133,96 +133,96 @@ end
 # SQL_BIT                           SQL_C_BIT                           Int8
 # SQL_TINYINT                       SQL_C_TINYINT                       Int8
 # SQL_BIGINT                        SQL_C_BIGINT                        Int64
-# SQL_BINARY                        SQL_C_BINARY                        Uint8
-# SQL_VARBINARY                     SQL_C_BINARY                        Uint8
-# SQL_LONGVARBINARY                 SQL_C_BINARY                        Uint8
+# SQL_BINARY                        SQL_C_BINARY                        UInt8
+# SQL_VARBINARY                     SQL_C_BINARY                        UInt8
+# SQL_LONGVARBINARY                 SQL_C_BINARY                        UInt8
 # SQL_TYPE_DATE                     SQL_C_TYPE_DATE                     SQLDate
 # SQL_TYPE_TIME                     SQL_C_TYPE_TIME                     SQLTime
 # SQL_TYPE_TIMESTAMP                SQL_C_TYPE_TIMESTAMP                SQLTimestamp
-# SQL_INTERVAL_MONTH                SQL_C_INTERVAL_MONTH                Uint8
-# SQL_INTERVAL_YEAR                 SQL_C_INTERVAL_YEAR                 Uint8
-# SQL_INTERVAL_YEAR_TO_MONTH        SQL_C_INTERVAL_YEAR_TO_MONTH        Uint8
-# SQL_INTERVAL_DAY                  SQL_C_INTERVAL_DAY                  Uint8
-# SQL_INTERVAL_HOUR                 SQL_C_INTERVAL_HOUR                 Uint8
-# SQL_INTERVAL_MINUTE               SQL_C_INTERVAL_MINUTE               Uint8
-# SQL_INTERVAL_SECOND               SQL_C_INTERVAL_SECOND               Uint8
-# SQL_INTERVAL_DAY_TO_HOUR          SQL_C_INTERVAL_DAY_TO_HOUR          Uint8
-# SQL_INTERVAL_DAY_TO_MINUTE        SQL_C_INTERVAL_DAY_TO_MINUTE        Uint8
-# SQL_INTERVAL_DAY_TO_SECOND        SQL_C_INTERVAL_DAY_TO_SECOND        Uint8
-# SQL_INTERVAL_HOUR_TO_MINUTE       SQL_C_INTERVAL_HOUR_TO_MINUTE       Uint8
-# SQL_INTERVAL_HOUR_TO_SECOND       SQL_C_INTERVAL_HOUR_TO_SECOND       Uint8
-# SQL_INTERVAL_MINUTE_TO_SECOND     SQL_C_INTERVAL_MINUTE_TO_SECOND     Uint8
-# SQL_GUID                          SQL_C_GUID                          Uint8
+# SQL_INTERVAL_MONTH                SQL_C_INTERVAL_MONTH                UInt8
+# SQL_INTERVAL_YEAR                 SQL_C_INTERVAL_YEAR                 UInt8
+# SQL_INTERVAL_YEAR_TO_MONTH        SQL_C_INTERVAL_YEAR_TO_MONTH        UInt8
+# SQL_INTERVAL_DAY                  SQL_C_INTERVAL_DAY                  UInt8
+# SQL_INTERVAL_HOUR                 SQL_C_INTERVAL_HOUR                 UInt8
+# SQL_INTERVAL_MINUTE               SQL_C_INTERVAL_MINUTE               UInt8
+# SQL_INTERVAL_SECOND               SQL_C_INTERVAL_SECOND               UInt8
+# SQL_INTERVAL_DAY_TO_HOUR          SQL_C_INTERVAL_DAY_TO_HOUR          UInt8
+# SQL_INTERVAL_DAY_TO_MINUTE        SQL_C_INTERVAL_DAY_TO_MINUTE        UInt8
+# SQL_INTERVAL_DAY_TO_SECOND        SQL_C_INTERVAL_DAY_TO_SECOND        UInt8
+# SQL_INTERVAL_HOUR_TO_MINUTE       SQL_C_INTERVAL_HOUR_TO_MINUTE       UInt8
+# SQL_INTERVAL_HOUR_TO_SECOND       SQL_C_INTERVAL_HOUR_TO_SECOND       UInt8
+# SQL_INTERVAL_MINUTE_TO_SECOND     SQL_C_INTERVAL_MINUTE_TO_SECOND     UInt8
+# SQL_GUID                          SQL_C_GUID                          UInt8
 
 # SQL Data Type Definitions
-const SQL_CHAR          = int16(  1) # Character string of fixed string length n.
-const SQL_VARCHAR       = int16( 12) # Variable-length character string with a maximum string length n.
-const SQL_LONGVARCHAR   = int16( -1) # Variable length character data. Maximum length is data source–dependent.
-const SQL_WCHAR         = int16( -8) # Unicode character string of fixed string length n
-const SQL_WVARCHAR      = int16( -9) # Unicode variable-length character string with a maximum string length n
-const SQL_WLONGVARCHAR  = int16(-10) # Unicode variable-length character data. Maximum length is data source–dependent
-const SQL_DECIMAL       = int16(  3) 
-const SQL_NUMERIC       = int16(  2)
-const SQL_SMALLINT      = int16(  5) # Exact numeric value with precision 5 and scale 0 (signed: –32,768 <= n <= 32,767, unsigned: 0 <= n <= 65,535)
-const SQL_INTEGER       = int16(  4) # Exact numeric value with precision 10 and scale 0 (signed: –2[31] <= n <= 2[31] – 1, unsigned: 0 <= n <= 2[32] – 1)
-const SQL_REAL          = int16(  7) # Signed, approximate, numeric value with a binary precision 24 (zero or absolute value 10[–38] to 10[38]).
-const SQL_FLOAT         = int16(  6) # Signed, approximate, numeric value with a binary precision of at least p. (The maximum precision is driver-defined.)
-const SQL_DOUBLE        = int16(  8) # Signed, approximate, numeric value with a binary precision 53 (zero or absolute value 10[–308] to 10[308]).
-const SQL_BIT           = int16( -7) # Single bit binary data.
-const SQL_TINYINT       = int16( -6) # Exact numeric value with precision 3 and scale 0 (signed: –128 <= n <= 127, unsigned: 0 <= n <= 255)
-const SQL_BIGINT        = int16( -5) # Exact numeric value with precision 19 (if signed) or 20 (if unsigned) and scale 0 (signed: –2[63] <= n <= 2[63] – 1, unsigned: 0 <= n <= 2[64] – 1)
-const SQL_BINARY        = int16( -2) # Binary data of fixed length n.
-const SQL_VARBINARY     = int16( -3) # Variable length binary data of maximum length n. The maximum is set by the user.
-const SQL_LONGVARBINARY = int16( -4) # Variable length binary data. Maximum length is data source–dependent.
-const SQL_TYPE_DATE     = int16( 91) # Year, month, and day fields, conforming to the rules of the Gregorian calendar.
-const SQL_TYPE_TIME     = int16( 92) # Hour, minute, and second fields, with valid values for hours of 00 to 23, 
+@compat const SQL_CHAR          = Int16(  1) # Character string of fixed string length n.
+@compat const SQL_VARCHAR       = Int16( 12) # Variable-length character string with a maximum string length n.
+@compat const SQL_LONGVARCHAR   = Int16( -1) # Variable length character data. Maximum length is data source–dependent.
+@compat const SQL_WCHAR         = Int16( -8) # Unicode character string of fixed string length n
+@compat const SQL_WVARCHAR      = Int16( -9) # Unicode variable-length character string with a maximum string length n
+@compat const SQL_WLONGVARCHAR  = Int16(-10) # Unicode variable-length character data. Maximum length is data source–dependent
+@compat const SQL_DECIMAL       = Int16(  3) 
+@compat const SQL_NUMERIC       = Int16(  2)
+@compat const SQL_SMALLINT      = Int16(  5) # Exact numeric value with precision 5 and scale 0 (signed: –32,768 <= n <= 32,767, unsigned: 0 <= n <= 65,535)
+@compat const SQL_INTEGER       = Int16(  4) # Exact numeric value with precision 10 and scale 0 (signed: –2[31] <= n <= 2[31] – 1, unsigned: 0 <= n <= 2[32] – 1)
+@compat const SQL_REAL          = Int16(  7) # Signed, approximate, numeric value with a binary precision 24 (zero or absolute value 10[–38] to 10[38]).
+@compat const SQL_FLOAT         = Int16(  6) # Signed, approximate, numeric value with a binary precision of at least p. (The maximum precision is driver-defined.)
+@compat const SQL_DOUBLE        = Int16(  8) # Signed, approximate, numeric value with a binary precision 53 (zero or absolute value 10[–308] to 10[308]).
+@compat const SQL_BIT           = Int16( -7) # Single bit binary data.
+@compat const SQL_TINYINT       = Int16( -6) # Exact numeric value with precision 3 and scale 0 (signed: –128 <= n <= 127, unsigned: 0 <= n <= 255)
+@compat const SQL_BIGINT        = Int16( -5) # Exact numeric value with precision 19 (if signed) or 20 (if unsigned) and scale 0 (signed: –2[63] <= n <= 2[63] – 1, unsigned: 0 <= n <= 2[64] – 1)
+@compat const SQL_BINARY        = Int16( -2) # Binary data of fixed length n.
+@compat const SQL_VARBINARY     = Int16( -3) # Variable length binary data of maximum length n. The maximum is set by the user.
+@compat const SQL_LONGVARBINARY = Int16( -4) # Variable length binary data. Maximum length is data source–dependent.
+@compat const SQL_TYPE_DATE     = Int16( 91) # Year, month, and day fields, conforming to the rules of the Gregorian calendar.
+@compat const SQL_TYPE_TIME     = Int16( 92) # Hour, minute, and second fields, with valid values for hours of 00 to 23, 
                                      # valid values for minutes of 00 to 59, and valid values for seconds of 00 to 61. Precision p indicates the seconds precision.
-const SQL_TYPE_TIMESTAMP = int16( 93) # Year, month, day, hour, minute, and second fields, with valid values as defined for the DATE and TIME data types.
+@compat const SQL_TYPE_TIMESTAMP = Int16( 93) # Year, month, day, hour, minute, and second fields, with valid values as defined for the DATE and TIME data types.
 
-#const SQL_INTERVAL_MONTH            = int16(102)
-#const SQL_INTERVAL_YEAR             = int16(101)
-#const SQL_INTERVAL_YEAR_TO_MONTH    = int16(107)
-#const SQL_INTERVAL_DAY              = int16(103)
-#const SQL_INTERVAL_HOUR             = int16(104)
-#const SQL_INTERVAL_MINUTE           = int16(105)
-#const SQL_INTERVAL_SECOND           = int16(106)
-#const SQL_INTERVAL_DAY_TO_HOUR      = int16(108)
-#const SQL_INTERVAL_DAY_TO_MINUTE    = int16(109)
-#const SQL_INTERVAL_DAY_TO_SECOND    = int16(110)
-#const SQL_INTERVAL_HOUR_TO_MINUTE   = int16(111)
-#const SQL_INTERVAL_HOUR_TO_SECOND   = int16(112)
-#const SQL_INTERVAL_MINUTE_TO_SECOND = int16(113)
-#const SQL_GUID                      = int16(-11) # Fixed length GUID.
+#@compat const SQL_INTERVAL_MONTH            = Int16(102)
+#@compat const SQL_INTERVAL_YEAR             = Int16(101)
+#@compat const SQL_INTERVAL_YEAR_TO_MONTH    = Int16(107)
+#@compat const SQL_INTERVAL_DAY              = Int16(103)
+#@compat const SQL_INTERVAL_HOUR             = Int16(104)
+#@compat const SQL_INTERVAL_MINUTE           = Int16(105)
+#@compat const SQL_INTERVAL_SECOND           = Int16(106)
+#@compat const SQL_INTERVAL_DAY_TO_HOUR      = Int16(108)
+#@compat const SQL_INTERVAL_DAY_TO_MINUTE    = Int16(109)
+#@compat const SQL_INTERVAL_DAY_TO_SECOND    = Int16(110)
+#@compat const SQL_INTERVAL_HOUR_TO_MINUTE   = Int16(111)
+#@compat const SQL_INTERVAL_HOUR_TO_SECOND   = Int16(112)
+#@compat const SQL_INTERVAL_MINUTE_TO_SECOND = Int16(113)
+#@compat const SQL_GUID                      = Int16(-11) # Fixed length GUID.
 
 # C Data Types
-const SQL_C_CHAR      = int16(  1)
-const SQL_C_WCHAR     = int16( -8)
-const SQL_C_DOUBLE    = int16(  8)
-const SQL_C_SHORT     = int16(  5)
-const SQL_C_LONG      = int16(  4)
-const SQL_C_FLOAT     = int16(  7)
-const SQL_C_BIT       = int16( -7)
-const SQL_C_TINYINT   = int16( -6)
-const SQL_C_BIGINT    = int16(-27)
-const SQL_C_BINARY    = int16( -2)
-const SQL_C_TYPE_DATE = int16( 91)
-const SQL_C_TYPE_TIME = int16( 92)
-const SQL_C_TYPE_TIMESTAMP = int16( 93)
+@compat const SQL_C_CHAR      = Int16(  1)
+@compat const SQL_C_WCHAR     = Int16( -8)
+@compat const SQL_C_DOUBLE    = Int16(  8)
+@compat const SQL_C_SHORT     = Int16(  5)
+@compat const SQL_C_LONG      = Int16(  4)
+@compat const SQL_C_FLOAT     = Int16(  7)
+@compat const SQL_C_BIT       = Int16( -7)
+@compat const SQL_C_TINYINT   = Int16( -6)
+@compat const SQL_C_BIGINT    = Int16(-27)
+@compat const SQL_C_BINARY    = Int16( -2)
+@compat const SQL_C_TYPE_DATE = Int16( 91)
+@compat const SQL_C_TYPE_TIME = Int16( 92)
+@compat const SQL_C_TYPE_TIMESTAMP = Int16( 93)
 
-#const SQL_C_INTERVAL_MONTH            = int16(102)
-#const SQL_C_INTERVAL_YEAR             = int16(101)
-#const SQL_C_INTERVAL_YEAR_TO_MONTH    = int16(107)
-#const SQL_C_INTERVAL_DAY              = int16(103)
-#const SQL_C_INTERVAL_HOUR             = int16(104)
-#const SQL_C_INTERVAL_MINUTE           = int16(105)
-#const SQL_C_INTERVAL_SECOND           = int16(106)
-#const SQL_C_INTERVAL_DAY_TO_HOUR      = int16(108)
-#const SQL_C_INTERVAL_DAY_TO_MINUTE    = int16(109)
-#const SQL_C_INTERVAL_DAY_TO_SECOND    = int16(110)
-#const SQL_C_INTERVAL_HOUR_TO_MINUTE   = int16(111)
-#const SQL_C_INTERVAL_HOUR_TO_SECOND   = int16(112)
-#const SQL_C_INTERVAL_MINUTE_TO_SECOND = int16(113)
-#const SQL_C_GUID                      = int16(-11)
+#@compat const SQL_C_INTERVAL_MONTH            = Int16(102)
+#@compat const SQL_C_INTERVAL_YEAR             = Int16(101)
+#@compat const SQL_C_INTERVAL_YEAR_TO_MONTH    = Int16(107)
+#@compat const SQL_C_INTERVAL_DAY              = Int16(103)
+#@compat const SQL_C_INTERVAL_HOUR             = Int16(104)
+#@compat const SQL_C_INTERVAL_MINUTE           = Int16(105)
+#@compat const SQL_C_INTERVAL_SECOND           = Int16(106)
+#@compat const SQL_C_INTERVAL_DAY_TO_HOUR      = Int16(108)
+#@compat const SQL_C_INTERVAL_DAY_TO_MINUTE    = Int16(109)
+#@compat const SQL_C_INTERVAL_DAY_TO_SECOND    = Int16(110)
+#@compat const SQL_C_INTERVAL_HOUR_TO_MINUTE   = Int16(111)
+#@compat const SQL_C_INTERVAL_HOUR_TO_SECOND   = Int16(112)
+#@compat const SQL_C_INTERVAL_MINUTE_TO_SECOND = Int16(113)
+#@compat const SQL_C_GUID                      = Int16(-11)
 
 # Julia mapping C structs
 immutable SQLDate
@@ -253,7 +253,7 @@ end
 
 Base.string(x::SQLTimestamp) = "$(x.year)-$(x.month)-$(x.day) $(x.hour):$(x.minute):$(x.second)"
 
-const SQL2C = [
+@compat const SQL2C = Dict(
     SQL_CHAR           => SQL_C_CHAR,
     SQL_VARCHAR        => SQL_C_CHAR,
     SQL_LONGVARCHAR    => SQL_C_CHAR,
@@ -275,9 +275,9 @@ const SQL2C = [
     SQL_LONGVARBINARY  => SQL_C_BINARY,
     SQL_TYPE_DATE      => SQL_C_TYPE_DATE,
     SQL_TYPE_TIME      => SQL_C_TYPE_TIME,
-    SQL_TYPE_TIMESTAMP => SQL_C_TYPE_TIMESTAMP]
+    SQL_TYPE_TIMESTAMP => SQL_C_TYPE_TIMESTAMP)
 
-const SQL2Julia = [
+@compat const SQL2Julia = Dict(
     SQL_CHAR           => SQLCHAR,
     SQL_VARCHAR        => SQLVARCHAR,
     SQL_LONGVARCHAR    => SQLVARCHAR,
@@ -294,14 +294,14 @@ const SQL2Julia = [
     SQL_BIT            => Int8,
     SQL_TINYINT        => Int8,
     SQL_BIGINT         => Int64,
-    SQL_BINARY         => Uint8,
-    SQL_VARBINARY      => Uint8,
-    SQL_LONGVARBINARY  => Uint8,
+    SQL_BINARY         => UInt8,
+    SQL_VARBINARY      => UInt8,
+    SQL_LONGVARBINARY  => UInt8,
     SQL_TYPE_DATE      => SQLDate,
     SQL_TYPE_TIME      => SQLTime,
-    SQL_TYPE_TIMESTAMP => SQLTimestamp]
+    SQL_TYPE_TIMESTAMP => SQLTimestamp)
 
-const SQL_TYPES = [
+@compat const SQL_TYPES = Dict(
       1 => "SQL_CHAR",
      12 => "SQL_VARCHAR",
      -1 => "SQL_LONGVARCHAR",
@@ -337,4 +337,4 @@ const SQL_TYPES = [
     111 => "SQL_INTERVAL_HOUR_TO_MINUTE",
     112 => "SQL_INTERVAL_HOUR_TO_SECOND",
     113 => "SQL_INTERVAL_MINUTE_TO_SECOND",
-    -11 => "SQL_GUID"]
+    -11 => "SQL_GUID")

--- a/src/backend.jl
+++ b/src/backend.jl
@@ -2,10 +2,10 @@ function ODBCAllocHandle(handletype, parenthandle)
     handle = Array(Ptr{Void},1)
     if @FAILED SQLAllocHandle(handletype,parenthandle,handle)
         error("[ODBC]: ODBC Handle Allocation Failed; Return Code: $ret")
-    else        
+    else
         #If allocation succeeded, retrieve handle pointer stored in handle's array index 1
         handle = handle[1]
-        if handletype == SQL_HANDLE_ENV 
+        if handletype == SQL_HANDLE_ENV
             if @FAILED SQLSetEnvAttr(handle,SQL_ATTR_ODBC_VERSION,SQL_OV_ODBC3)
                 #If version-setting fails, release environment handle and set global env variable to a null pointer
                 SQLFreeHandle(SQL_HANDLE_ENV,handle)
@@ -27,7 +27,7 @@ end
 
 # Alternative connect function that allows user to create datasources on the fly through opening the ODBC admin
 @compat function ODBCDriverConnect!(dbc::Ptr{Void},conn_string::String,driver_prompt::UInt16)
-    window_handle = C_NULL    
+    window_handle = C_NULL
     @windows_only window_handle = ccall((:GetForegroundWindow, :user32), Ptr{Void}, () )
     @windows_only driver_prompt = SQL_DRIVER_PROMPT
     out_buff = Array(Int16,1)
@@ -65,7 +65,7 @@ end
             datatype = Array(Int16, 1)
             column_size = Array(Int, 1)
             decimal_digits = Array(Int16, 1)
-            nullable = Array(Int16, 1) 
+            nullable = Array(Int16, 1)
             SQLDescribeCol(stmt, x, column_name, name_length, datatype, column_size, decimal_digits, nullable)
             push!(colnames, ODBCClean(column_name, 1, name_length[1]))
             push!(coltypes, (get(SQL_TYPES, Int(datatype[1]), "SQL_CHAR"), datatype[1]))
@@ -82,7 +82,6 @@ end
     meta.rows == 0 && return (Any[],Any[],0)
     rowset = MULTIROWFETCH > meta.rows ? (meta.rows < 0 ? 1 : meta.rows) : MULTIROWFETCH
     SQLSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE, UInt(rowset), SQL_IS_UINTEGER)
-    
     # these Any arrays are where the ODBC manager dumps result data
     indicator = Any[]
     columns = Any[]
@@ -105,7 +104,7 @@ end
     return (columns, indicator, rowset)
 end
 
-# ODBCColumnAllocate is used to allocate the raw 
+# ODBCColumnAllocate is used to allocate the raw
 # underlying C-type buffers to be bound in SQLBindCol
 ODBCColumnAllocate(x,y,z)                       = (Array(x,z),sizeof(x))
 @compat ODBCColumnAllocate(x::Type{UInt8},y,z)  = (zeros(x,(y,z)),y)
@@ -147,7 +146,7 @@ end
         nas[i+dsto-1] = ind[i] < 0
         raw = src[1:div(ind[i], 2), i]
         str = utf16(convert(Ptr{UInt16}, raw), length(raw))
-        dest[i+dsto-1] = str 
+        dest[i+dsto-1] = str
     end
 end
 
@@ -223,7 +222,7 @@ function ODBCDirectToFile(stmt::Ptr{Void},meta::Metadata,columns::Array{Any,1},r
     return DataFrame()
 end
 
-# used to 'clear' a statement of bound columns, resultsets, 
+# used to 'clear' a statement of bound columns, resultsets,
 # and other bound parameters in preparation for a subsequent query
 function ODBCFreeStmt!(stmt)
     SQLFreeStmt(stmt,SQL_CLOSE)
@@ -231,7 +230,7 @@ function ODBCFreeStmt!(stmt)
     SQLFreeStmt(stmt,SQL_RESET_PARAMS)
 end
 
-# Takes an SQL handle as input and retrieves any error messages 
+# Takes an SQL handle as input and retrieves any error messages
 # associated with that handle; there may be more than one
 @compat function ODBCError(handletype::Int16,handle::Ptr{Void})
     i = Int16(1)

--- a/src/backend.jl
+++ b/src/backend.jl
@@ -26,7 +26,7 @@ function ODBCConnect!(dbc::Ptr{Void},dsn::String,username::String,password::Stri
 end
 
 # Alternative connect function that allows user to create datasources on the fly through opening the ODBC admin
-function ODBCDriverConnect!(dbc::Ptr{Void},conn_string::String,driver_prompt::Uint16)
+@compat function ODBCDriverConnect!(dbc::Ptr{Void},conn_string::String,driver_prompt::UInt16)
     window_handle = C_NULL    
     @windows_only window_handle = ccall((:GetForegroundWindow, :user32), Ptr{Void}, () )
     @windows_only driver_prompt = SQL_DRIVER_PROMPT
@@ -46,7 +46,7 @@ function ODBCQueryExecute(stmt::Ptr{Void}, querystring::String)
 end
 
 # Retrieve resultset metadata once query is processed, Metadata type is returned
-function ODBCMetadata(stmt::Ptr{Void},querystring::String)
+@compat function ODBCMetadata(stmt::Ptr{Void},querystring::String)
         #Allocate space for and fetch number of columns and rows in resultset
         cols = Array(Int16,1)
         rows = Array(Int,1)
@@ -60,28 +60,28 @@ function ODBCMetadata(stmt::Ptr{Void},querystring::String)
         colnulls  = Int16[]
         #Allocate space for and fetch the name, type, size, etc. for each column
         for x = 1:cols[1]
-            column_name = zeros(Uint8,256)
-            name_length = Array(Int16,1)
-            datatype = Array(Int16,1)
-            column_size = Array(Int,1)
-            decimal_digits = Array(Int16,1)
-            nullable = Array(Int16,1) 
-            SQLDescribeCol(stmt,x,column_name,name_length,datatype,column_size,decimal_digits,nullable)
-            push!(colnames,ODBCClean(column_name,1,name_length[1]))
-            push!(coltypes,(get(SQL_TYPES,int(datatype[1]),"SQL_CHAR"),datatype[1]))
-            push!(colsizes,int(column_size[1]))
-            push!(coldigits,decimal_digits[1])
-            push!(colnulls,nullable[1])
+            column_name = zeros(UInt8, 256)
+            name_length = Array(Int16, 1)
+            datatype = Array(Int16, 1)
+            column_size = Array(Int, 1)
+            decimal_digits = Array(Int16, 1)
+            nullable = Array(Int16, 1) 
+            SQLDescribeCol(stmt, x, column_name, name_length, datatype, column_size, decimal_digits, nullable)
+            push!(colnames, ODBCClean(column_name, 1, name_length[1]))
+            push!(coltypes, (get(SQL_TYPES, Int(datatype[1]), "SQL_CHAR"), datatype[1]))
+            push!(colsizes, Int(column_size[1]))
+            push!(coldigits, decimal_digits[1])
+            push!(colnulls, nullable[1])
         end
-    return Metadata(querystring,int(cols[1]),rows[1],colnames,coltypes,colsizes,coldigits,colnulls)
+    return Metadata(querystring, Int(cols[1]), rows[1], colnames, coltypes, colsizes, coldigits, colnulls)
 end
 
 # [Using resultset metadata, allocate space/arrays for previously generated resultset, retrieve results
-function ODBCBindCols(stmt::Ptr{Void},meta::Metadata)
+@compat function ODBCBindCols(stmt::Ptr{Void},meta::Metadata)
     #with catalog functions or all-filtering WHERE clauses, resultsets can have 0 rows/cols
     meta.rows == 0 && return (Any[],Any[],0)
     rowset = MULTIROWFETCH > meta.rows ? (meta.rows < 0 ? 1 : meta.rows) : MULTIROWFETCH
-    SQLSetStmtAttr(stmt,SQL_ATTR_ROW_ARRAY_SIZE,uint(rowset),SQL_IS_UINTEGER)
+    SQLSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE, UInt(rowset), SQL_IS_UINTEGER)
     
     # these Any arrays are where the ODBC manager dumps result data
     indicator = Any[]
@@ -91,10 +91,10 @@ function ODBCBindCols(stmt::Ptr{Void},meta::Metadata)
         #we need the C type so the ODBC manager knows how to store the data
         ctype = get(SQL2C,sqltype,SQL_C_CHAR)
         #we need the julia type that corresponds to the C type size
-        jtype = get(SQL2Julia,sqltype,Uint8)
+        jtype = get(SQL2Julia,sqltype,UInt8)
         holder, jlsize = ODBCColumnAllocate(jtype,meta.colsizes[x]+1,rowset)
         ind = Array(Int,rowset)
-        if @SUCCEEDED ODBC.SQLBindCols(stmt,x,ctype,holder,int(jlsize),ind)
+        if @SUCCEEDED ODBC.SQLBindCols(stmt,x,ctype,holder,Int(jlsize),ind)
             push!(columns,holder)
             push!(indicator,ind)
         else #SQL_ERROR
@@ -107,26 +107,26 @@ end
 
 # ODBCColumnAllocate is used to allocate the raw 
 # underlying C-type buffers to be bound in SQLBindCol
-ODBCColumnAllocate(x,y,z)               = (Array(x,z),sizeof(x))
-ODBCColumnAllocate(x::Type{Uint8},y,z)  = (zeros(x,(y,z)),y)
-ODBCColumnAllocate(x::Type{Uint16},y,z) = (zeros(x,(y,z)),y*2)
-ODBCColumnAllocate(x::Type{Uint32},y,z) = (zeros(x,(y,z)),y*4)
+ODBCColumnAllocate(x,y,z)                       = (Array(x,z),sizeof(x))
+@compat ODBCColumnAllocate(x::Type{UInt8},y,z)  = (zeros(x,(y,z)),y)
+@compat ODBCColumnAllocate(x::Type{UInt16},y,z) = (zeros(x,(y,z)),y*2)
+@compat ODBCColumnAllocate(x::Type{UInt32},y,z) = (zeros(x,(y,z)),y*4)
 
 # ODBCAllocate is the Julia type array that the raw underlying C-type buffer
 # data is converted to when moved to a DataFrame or written to file
-ODBCAllocate(x,y)                        = zeros(eltype(typeof(x)),y)
-ODBCAllocate(x::Array{Uint8,2},y)        = Array(UTF8String,y)
-ODBCAllocate(x::Array{Uint16,2},y)       = Array(UTF16String,y)
-ODBCAllocate(x::Array{Uint32,2},y)       = Array(UTF8String,y)
+ODBCAllocate(x,y)                           = zeros(eltype(typeof(x)),y)
+@compat ODBCAllocate(x::Array{UInt8,2},y)   = Array(UTF8String,y)
+@compat ODBCAllocate(x::Array{UInt16,2},y)  = Array(UTF16String,y)
+@compat ODBCAllocate(x::Array{UInt32,2},y)  = Array(UTF8String,y)
 ODBCAllocate(x::Array{SQLDate,1},y)      = Array(SQLDate,y)
 ODBCAllocate(x::Array{SQLTime,1},y)      = Array(SQLTime,y)
 ODBCAllocate(x::Array{SQLTimestamp,1},y) = Array(SQLTimestamp,y)
 
 # ODBCClean does any necessary transformations from raw C-type to Julia type
 ODBCClean(x,y,z) = x[y]
-ODBCClean(x::Array{Uint8},y,z)          = utf8(x[1:z,y])
-ODBCClean(x::Array{Uint16},y,z)         = utf16(x[1:z,y])
-ODBCClean(x::Array{Uint32},y,z)         = utf32(x[1:z,y])
+@compat ODBCClean(x::Array{UInt8},y,z)          = utf8(x[1:z,y])
+@compat ODBCClean(x::Array{UInt16},y,z)         = utf16(x[1:z,y])
+@compat ODBCClean(x::Array{UInt32},y,z)         = utf32(x[1:z,y])
 
 function ODBCCopy!(dest,dsto,src,n,ind,nas)
     for i = 1:n
@@ -135,26 +135,26 @@ function ODBCCopy!(dest,dsto,src,n,ind,nas)
     end
 end
 
-function ODBCCopy!(dest::Array{UTF8String},dsto,src::Array{Uint8,2},n,ind,nas)
+@compat function ODBCCopy!(dest::Array{UTF8String},dsto,src::Array{UInt8,2},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
         dest[i+dsto-1] = utf8(bytestring(src[1:ind[i],i]))
     end
 end
 
-function ODBCCopy!(dest::Array{UTF16String},dsto,src::Array{Uint16,2},n,ind,nas)
+@compat function ODBCCopy!(dest::Array{UTF16String},dsto,src::Array{UInt16,2},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
         raw = src[1:div(ind[i], 2), i]
-        str = utf16(convert(Ptr{Uint16}, raw), length(raw))
+        str = utf16(convert(Ptr{UInt16}, raw), length(raw))
         dest[i+dsto-1] = str 
     end
 end
 
-function ODBCCopy!(dest::Array{UTF8String},dsto,src::Array{Uint32},n,ind,nas)
+@compat function ODBCCopy!(dest::Array{UTF8String},dsto,src::Array{UInt32},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        dest[i+dsto-1] = utf8(bytestring(convert(Array{Uint8},src[1:div(ind[i],4),i])))
+        dest[i+dsto-1] = utf8(bytestring(convert(Array{UInt8},src[1:div(ind[i],4),i])))
     end
 end
 
@@ -182,7 +182,7 @@ function ODBCFetchDataFrame(stmt::Ptr{Void},meta::Metadata,columns::Array{Any,1}
         r += rows
     end
     toc()
-    cols = {DataArray(cols[col],nas[col]) for col = 1:length(cols)}
+    @compat cols = Any[DataArray(cols[col],nas[col]) for col = 1:length(cols)]
     resultset = DataFrame(cols, DataFrames.Index(Symbol[DataFrames.identifier(i) for i in meta.colnames]))
 end
 
@@ -205,7 +205,7 @@ function ODBCFetchDataFramePush!(stmt::Ptr{Void},meta::Metadata,columns::Array{A
             append!(nas[col],tempna)
         end
     end
-    cols = {DataArray(cols[col],nas[col]) for col = 1:length(cols)}
+    @compat cols = Any[DataArray(cols[col],nas[col]) for col = 1:length(cols)]
     resultset = DataFrame(cols, DataFrames.Index(Symbol[DataFrames.identifier(i) for i in meta.colnames]))
 end
 
@@ -233,16 +233,16 @@ end
 
 # Takes an SQL handle as input and retrieves any error messages 
 # associated with that handle; there may be more than one
-function ODBCError(handletype::Int16,handle::Ptr{Void})
-    i = int16(1)
-    state = zeros(Uint8,6)
-    error_msg = zeros(Uint8, 1024)
+@compat function ODBCError(handletype::Int16,handle::Ptr{Void})
+    i = Int16(1)
+    state = zeros(UInt8,6)
+    error_msg = zeros(UInt8, 1024)
     native = zeros(Int,1)
     msg_length = zeros(Int16,1)
     while @SUCCEEDED SQLGetDiagRec(handletype,handle,i,state,native,error_msg,msg_length)
         st  = ODBCClean(state,1,5)
         msg = ODBCClean(error_msg, 1, msg_length[1])
         println("[ODBC] $st: $msg")
-        i = int16(i+1)
+        i = Int16(i+1)
     end
 end

--- a/src/userfacing.jl
+++ b/src/userfacing.jl
@@ -1,4 +1,4 @@
-# Connect to DSN, returns Connection object, 
+# Connect to DSN, returns Connection object,
 # also stores Connection information in global default
 # 'conn' object and global 'Connections' connections array
 function connect(dsn::String; usr::String="", pwd::String="")
@@ -35,8 +35,8 @@ function advancedconnect(conn_string::String="", driver_prompt::Uint16=SQL_DRIVE
     return conn
 end
 
-# query: Sends query string to DBMS, 
-# once executed, space is allocated and 
+# query: Sends query string to DBMS,
+# once executed, space is allocated and
 # results and resultset metadata are returned
 function query(querystring::String, conn::Connection=conn; output::Output=DataFrame, delim::Char=',')
     if conn == null_conn
@@ -58,7 +58,7 @@ function query(querystring::String, conn::Connection=conn; output::Output=DataFr
                     resultset = ODBCFetchDataFramePush!(conn.stmt_ptr, meta,columns, rowset,indicator)
                 end
             else
-                resultset = ODBCDirectToFile(conn.stmt_ptr, meta,columns, 
+                resultset = ODBCDirectToFile(conn.stmt_ptr, meta,columns,
                                              rowset, output, delim, length(holder))
             end
             push!(holder,resultset)
@@ -70,21 +70,21 @@ function query(querystring::String, conn::Connection=conn; output::Output=DataFr
     return conn.resultset
 end
 
-# sql"..." string literal for convenience; 
+# sql"..." string literal for convenience;
 # it doesn't do anything different than query right now,
 # but we could potentially do some interesting things here
 macro sql_str(s)
     query(s)
 end
 
-# Replaces backticks in the query string with escaped quotes 
+# Replaces backticks in the query string with escaped quotes
 # for convenience in using "" in column names, etc.
 macro query(x)
     :(query(replace($x, '`', '\"')))
 end
 
 # querymeta: Sends query string to DBMS, once executed, return resultset metadata
-# it may seem odd to include the other arguments for querymeta, 
+# it may seem odd to include the other arguments for querymeta,
 # but it's so switching between query and querymeta doesn't require exluding args (convenience)
 function querymeta(querystring::String,conn::Connection=conn; output::Output=DataFrame,delim::Char=',')
     if conn == null_conn
@@ -107,7 +107,7 @@ function disconnect(connection::Connection=conn)
     ODBCFreeStmt!(connection.stmt_ptr)
     SQLDisconnect(connection.dbc_ptr)
     for x = 1:length(Connections)
-        if connection.dsn == Connections[x].dsn && 
+        if connection.dsn == Connections[x].dsn &&
            connection.number == Connections[x].number
             splice!(Connections,x)
             if conn === connection
@@ -132,7 +132,7 @@ function listdrivers()
     desc_length = zeros(Int16, 1)
     driver_attr = zeros(Uint8, 256)
     attr_length = zeros(Int16, 1)
-    while @SUCCEEDED SQLDrivers(env, driver_desc, desc_length, driver_attr, attr_length)    
+    while @SUCCEEDED SQLDrivers(env, driver_desc, desc_length, driver_attr, attr_length)
         push!(descriptions, ODBCClean(driver_desc, 1, desc_length[1]))
         push!(attributes,   ODBCClean(driver_attr, 1, attr_length[1]))
     end


### PR DESCRIPTION
I've added `Compat` dependency and changed the syntax where 0.4 caused deprecation warnings. I've also removed whitespace in a separate commit.